### PR TITLE
feat: save/feed, songs page, i18n, and various improvements

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 24.9.0
+nodejs 25.9.0

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier . --check"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.4",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.105.4
+        version: 2.105.4
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -205,89 +208,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -354,24 +373,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -403,6 +426,33 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -528,41 +578,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1087,6 +1145,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2072,6 +2134,38 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@supabase/auth-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.4':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.105.4':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.4':
+    dependencies:
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2926,6 +3020,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  sharp: true
+  unrs-resolver: true
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/src/app/components/NotePanel.tsx
+++ b/src/app/components/NotePanel.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { NoteName } from "@/core/types";
+import { colorForNote } from "@/ui/color";
+
+interface Props {
+  rangeNotes: NoteName[];
+  allowedNotes: NoteName[] | null;
+  onNoteClick: (note: NoteName) => void;
+  onClear: () => void;
+}
+
+export function NotePanel({ rangeNotes, allowedNotes, onNoteClick, onClear }: Props) {
+  return (
+    <div className="note-panel">
+      <div className="note-panel-header">
+        <div>
+          <span className="note-panel-title">Active notes</span>
+          {allowedNotes === null && (
+            <span className="note-panel-hint">Tap to exclude notes</span>
+          )}
+        </div>
+        {allowedNotes !== null && (
+          <button className="note-panel-reset" onClick={onClear}>
+            Show all
+          </button>
+        )}
+      </div>
+      <div className="note-panel-chips">
+        {rangeNotes.map((noteName) => {
+          const isActive = allowedNotes === null || allowedNotes.includes(noteName);
+          return (
+            <button
+              key={noteName}
+              className={`note-chip ${isActive ? "active" : ""}`}
+              style={
+                isActive
+                  ? { backgroundColor: colorForNote(noteName) }
+                  : { borderColor: colorForNote(noteName), color: colorForNote(noteName) }
+              }
+              onClick={() => onNoteClick(noteName)}
+            >
+              {noteName}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/NotePanel.tsx
+++ b/src/app/components/NotePanel.tsx
@@ -1,28 +1,33 @@
 "use client";
 
 import type { NoteName } from "@/core/types";
+import type { Locale } from "@/lib/i18n";
+import { translations } from "@/lib/i18n";
 import { colorForNote } from "@/ui/color";
 
 interface Props {
   rangeNotes: NoteName[];
   allowedNotes: NoteName[] | null;
+  locale: Locale;
   onNoteClick: (note: NoteName) => void;
   onClear: () => void;
 }
 
-export function NotePanel({ rangeNotes, allowedNotes, onNoteClick, onClear }: Props) {
+export function NotePanel({ rangeNotes, allowedNotes, locale, onNoteClick, onClear }: Props) {
+  const t = translations[locale];
+
   return (
     <div className="note-panel">
       <div className="note-panel-header">
         <div>
-          <span className="note-panel-title">Active notes</span>
+          <span className="note-panel-title">{t.activeNotes}</span>
           {allowedNotes === null && (
-            <span className="note-panel-hint">Tap to exclude notes</span>
+            <span className="note-panel-hint">{t.tapToExclude}</span>
           )}
         </div>
         {allowedNotes !== null && (
           <button className="note-panel-reset" onClick={onClear}>
-            Show all
+            {t.showAll}
           </button>
         )}
       </div>

--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -2,14 +2,18 @@
 
 import { useState } from "react";
 import type { Song } from "@/core/types";
+import type { Locale } from "@/lib/i18n";
+import { translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
 
 interface Props {
   song: Song;
+  locale: Locale;
   onClose: () => void;
 }
 
-export function SaveModal({ song, onClose }: Props) {
+export function SaveModal({ song, locale, onClose }: Props) {
+  const t = translations[locale];
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [saving, setSaving] = useState(false);
@@ -32,11 +36,11 @@ export function SaveModal({ song, onClose }: Props) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
-        <h2 className="modal-title">Save Song</h2>
+        <h2 className="modal-title">{t.saveModalTitle}</h2>
         <div className="modal-fields">
           <input
             className="modal-input"
-            placeholder="Song title"
+            placeholder={t.titlePlaceholder}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             maxLength={60}
@@ -44,7 +48,7 @@ export function SaveModal({ song, onClose }: Props) {
           />
           <input
             className="modal-input"
-            placeholder="Your name"
+            placeholder={t.authorPlaceholder}
             value={author}
             onChange={(e) => setAuthor(e.target.value)}
             maxLength={40}
@@ -52,14 +56,14 @@ export function SaveModal({ song, onClose }: Props) {
         </div>
         <div className="modal-actions">
           <button className="modal-cancel" onClick={onClose}>
-            Cancel
+            {t.cancel}
           </button>
           <button
             className="modal-save"
             onClick={handleSave}
             disabled={saving || !title.trim() || !author.trim()}
           >
-            {saving ? "Saving..." : "Save"}
+            {saving ? t.saving : t.save}
           </button>
         </div>
       </div>

--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import type { Song } from "@/core/types";
+import { supabase } from "@/lib/supabase";
+
+interface Props {
+  song: Song;
+  onClose: () => void;
+}
+
+export function SaveModal({ song, onClose }: Props) {
+  const [title, setTitle] = useState("");
+  const [author, setAuthor] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!title.trim() || !author.trim()) return;
+    setSaving(true);
+    try {
+      await supabase.from("songs").insert({
+        title: title.trim(),
+        author: author.trim(),
+        song_data: song,
+      });
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">Save Song</h2>
+        <div className="modal-fields">
+          <input
+            className="modal-input"
+            placeholder="Song title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={60}
+            autoFocus
+          />
+          <input
+            className="modal-input"
+            placeholder="Your name"
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            maxLength={40}
+          />
+        </div>
+        <div className="modal-actions">
+          <button className="modal-cancel" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="modal-save"
+            onClick={handleSave}
+            disabled={saving || !title.trim() || !author.trim()}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1149,3 +1149,28 @@ a {
     font-size: 15px;
   }
 }
+
+/* Locale toggle button */
+.locale-toggle {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1.5px solid var(--grid-line);
+  background: transparent;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.locale-toggle:hover {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-color: transparent;
+  color: white;
+}
+
+.songs-header .locale-toggle {
+  margin-left: auto;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -850,3 +850,302 @@ a {
 .bubble.preview {
   opacity: 0.5;
 }
+
+/* Songs nav link (editor header) */
+.songs-nav-link {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: 2px solid transparent;
+  background: linear-gradient(var(--header-bg), var(--header-bg)) padding-box,
+    linear-gradient(135deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3) border-box;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s ease;
+  text-decoration: none;
+}
+
+.songs-nav-link:hover {
+  opacity: 0.75;
+}
+
+/* Save button */
+.save-btn {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: none;
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+
+.save-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(17, 153, 142, 0.4);
+}
+
+/* Save modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: var(--header-bg);
+  border-radius: 16px;
+  padding: 24px;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modal-title {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.modal-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.modal-input {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.modal-input:focus {
+  border-color: #667eea;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.modal-cancel {
+  padding: 8px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--grid-line);
+  background: transparent;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+.modal-cancel:hover {
+  opacity: 1;
+}
+
+.modal-save {
+  padding: 8px 20px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.modal-save:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.modal-save:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* =====================
+   Songs page
+   ===================== */
+
+.songs-page {
+  min-height: 100vh;
+  background: var(--background);
+  display: flex;
+  flex-direction: column;
+}
+
+.songs-header {
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--grid-line);
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.songs-back-btn {
+  padding: 10px 20px;
+  border-radius: 20px;
+  border: none;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  flex-shrink: 0;
+}
+
+.songs-back-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+.songs-heading {
+  font-size: 26px;
+  font-weight: 800;
+  background: linear-gradient(135deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.songs-main {
+  flex: 1;
+  padding: 32px 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.songs-status {
+  text-align: center;
+  font-size: 18px;
+  opacity: 0.5;
+  margin-top: 80px;
+}
+
+.songs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.song-card {
+  background: var(--grid-bg);
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.song-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
+}
+
+.song-card-art {
+  height: 90px;
+  flex-shrink: 0;
+}
+
+.song-card-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.song-card-title {
+  font-size: 17px;
+  font-weight: 800;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  margin-bottom: 2px;
+}
+
+.song-card-author {
+  font-size: 13px;
+  font-weight: 600;
+  opacity: 0.6;
+}
+
+.song-card-time {
+  font-size: 11px;
+  opacity: 0.4;
+  margin-bottom: 12px;
+}
+
+.song-card-play {
+  display: block;
+  text-align: center;
+  padding: 12px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #00c853, #00e676);
+  color: white;
+  font-size: 16px;
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  margin-top: auto;
+}
+
+.song-card-play:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 200, 83, 0.4);
+}
+
+@media (max-width: 480px) {
+  .songs-header {
+    padding: 12px 16px;
+  }
+
+  .songs-heading {
+    font-size: 20px;
+  }
+
+  .songs-main {
+    padding: 20px 16px;
+  }
+
+  .songs-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 14px;
+  }
+
+  .song-card-title {
+    font-size: 15px;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+
+export const dynamic = "force-dynamic";
 import "./globals.css";
 
 const geistSans = Geist({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
+import Link from "next/link";
 import type { DrumId, InstrumentId, MelodyNote, NoteName, Song } from "@/core/types";
 import { DEFAULT_SONG } from "@/core/defaults";
 import {
@@ -18,6 +19,10 @@ import { colorForDrum, colorForNote } from "@/ui/color";
 import { buildNoteRows, buildRangeNotes, findMelodyNoteAt, getNotePosition } from "@/ui/grid";
 import { AudioEngine } from "@/audio/engine";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
+import { supabase } from "@/lib/supabase";
+import { SaveModal } from "./components/SaveModal";
+import { NotePanel } from "./components/NotePanel";
+import { BPM_MIN, BPM_MAX, BPM_STEP, HISTORY_LIMIT } from "@/core/defaults";
 
 const DRUM_ROWS: DrumId[] = ["hihat", "snare", "kick"];
 
@@ -34,6 +39,7 @@ export default function Home() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [playheadStep, setPlayheadStep] = useState<number | null>(null);
   const [isNotePanelOpen, setIsNotePanelOpen] = useState(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const gridRef = useRef<HTMLDivElement>(null);
   const gridContainerRef = useRef<HTMLDivElement>(null);
@@ -44,8 +50,26 @@ export default function Home() {
     songRef.current = song;
   }, [song]);
 
+  // ?load=<id> で曲を読み込む
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const loadId = params.get("load");
+    if (!loadId) return;
+    supabase
+      .from("songs")
+      .select("song_data")
+      .eq("id", loadId)
+      .single()
+      .then(({ data }) => {
+        if (data?.song_data) {
+          setSong(data.song_data as Song);
+          window.history.replaceState({}, "", "/");
+        }
+      });
+  }, []);
+
   const pushHistory = useCallback((snapshot: Song) => {
-    setHistory((h) => [...h.slice(-49), snapshot]);
+    setHistory((h) => [...h.slice(-(HISTORY_LIMIT - 1)), snapshot]);
   }, []);
 
   const getEngine = useCallback(() => {
@@ -55,7 +79,6 @@ export default function Home() {
     return engineRef.current;
   }, []);
 
-  // Drag interaction callbacks
   const handleNoteCreate = useCallback(
     (noteName: NoteName, step: number): string | null => {
       const newSong = addMelodyNote(song, {
@@ -77,23 +100,21 @@ export default function Home() {
     [song, getEngine, pushHistory]
   );
 
-  const handleNoteRemove = useCallback((noteId: string) => {
-    pushHistory(song);
-    setSong((prev) => removeMelodyNote(prev, noteId));
-  }, [song, pushHistory]);
-
-  const handleNoteDurationChange = useCallback(
-    (noteId: string, duration: number) => {
-      setSong((prev) => setMelodyNoteDuration(prev, noteId, duration));
+  const handleNoteRemove = useCallback(
+    (noteId: string) => {
+      pushHistory(song);
+      setSong((prev) => removeMelodyNote(prev, noteId));
     },
-    []
+    [song, pushHistory]
   );
+
+  const handleNoteDurationChange = useCallback((noteId: string, duration: number) => {
+    setSong((prev) => setMelodyNoteDuration(prev, noteId, duration));
+  }, []);
 
   const handleDrumToggle = useCallback(
     (drumId: DrumId, step: number) => {
-      const wasHit = song.drums.hits.some(
-        (h) => h.drumId === drumId && h.step === step
-      );
+      const wasHit = song.drums.hits.some((h) => h.drumId === drumId && h.step === step);
       pushHistory(song);
       setSong((prev) => toggleDrumHit(prev, { step, drumId }));
       if (!wasHit) {
@@ -112,21 +133,17 @@ export default function Home() {
     pushHistory(songRef.current);
   }, [pushHistory]);
 
-  const {
-    isDragging,
-    getMelodyCellHandlers,
-    getDrumCellHandlers,
-    containerHandlers,
-  } = useDragInteraction({
-    gridRef,
-    gridContainerRef,
-    onNoteCreate: handleNoteCreate,
-    onNoteRemove: handleNoteRemove,
-    onNoteDurationChange: handleNoteDurationChange,
-    onDragStart: handleDragStart,
-    onDrumToggle: handleDrumToggle,
-    findNoteAt,
-  });
+  const { isDragging, getMelodyCellHandlers, getDrumCellHandlers, containerHandlers } =
+    useDragInteraction({
+      gridRef,
+      gridContainerRef,
+      onNoteCreate: handleNoteCreate,
+      onNoteRemove: handleNoteRemove,
+      onNoteDurationChange: handleNoteDurationChange,
+      onDragStart: handleDragStart,
+      onDrumToggle: handleDrumToggle,
+      findNoteAt,
+    });
 
   const noteRows = buildNoteRows(song);
   const rangeNotes = buildRangeNotes(song);
@@ -136,16 +153,13 @@ export default function Home() {
 
   const handlePlay = async () => {
     if (isPlaying) return;
-
     try {
       const engine = getEngine();
       await engine.init();
       setIsPlaying(true);
       engine.play(
         () => songRef.current,
-        (step) => {
-          setPlayheadStep(step);
-        }
+        (step) => setPlayheadStep(step)
       );
     } catch (error) {
       console.error("Failed to start audio:", error);
@@ -153,9 +167,7 @@ export default function Home() {
   };
 
   const handleStop = () => {
-    if (engineRef.current) {
-      engineRef.current.stop();
-    }
+    if (engineRef.current) engineRef.current.stop();
     setIsPlaying(false);
     setPlayheadStep(null);
   };
@@ -174,15 +186,10 @@ export default function Home() {
 
   const handleBpmChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
-    if (!isNaN(value)) {
-      setSong((prev) => ({ ...prev, bpm: value }));
-    }
+    if (!isNaN(value)) setSong((prev) => ({ ...prev, bpm: value }));
   };
 
-  const handlePitchBoundChange = (
-    bound: "min" | "max",
-    direction: "up" | "down"
-  ) => {
+  const handlePitchBoundChange = (bound: "min" | "max", direction: "up" | "down") => {
     setSong((prev) => adjustPitchBound(prev, bound, direction));
   };
 
@@ -194,7 +201,6 @@ export default function Home() {
     (noteName: NoteName) => {
       const current = song.constraints.allowedNotes;
       if (current === null) {
-        // Enter filter mode: start with all notes, deselect the clicked one
         const withoutClicked = buildRangeNotes(song).filter((n) => n !== noteName);
         if (withoutClicked.length === 0) return;
         setSong((prev) => setAllowedNotes(prev, withoutClicked));
@@ -214,7 +220,6 @@ export default function Home() {
     const isBeatStart = step % song.stepsPerBeat === 0;
     const isPlayhead = playheadStep === step;
     const handlers = getMelodyCellHandlers(noteName, step);
-
     return (
       <div
         key={step}
@@ -231,7 +236,6 @@ export default function Home() {
     const position = getNotePosition(note, step);
     const isStart = step === note.startStep;
     const color = colorForNote(note.note);
-
     return (
       <div
         className={`bubble ${position} ${isStart ? "start-highlight" : ""}`}
@@ -241,14 +245,11 @@ export default function Home() {
   };
 
   const renderDrumCell = (drumId: DrumId, step: number) => {
-    const hasHit = song.drums.hits.some(
-      (h) => h.drumId === drumId && h.step === step
-    );
+    const hasHit = song.drums.hits.some((h) => h.drumId === drumId && h.step === step);
     const isBeatStart = step % song.stepsPerBeat === 0;
     const color = colorForDrum(drumId);
     const isPlayhead = playheadStep === step;
     const handlers = getDrumCellHandlers(drumId, step);
-
     return (
       <div
         key={step}
@@ -256,9 +257,7 @@ export default function Home() {
         onMouseDown={handlers.onMouseDown}
         onTouchStart={handlers.onTouchStart}
       >
-        {hasHit && (
-          <div className="drum-bubble" style={{ backgroundColor: color }} />
-        )}
+        {hasHit && <div className="drum-bubble" style={{ backgroundColor: color }} />}
       </div>
     );
   };
@@ -299,9 +298,9 @@ export default function Home() {
               className="control-slider"
               value={song.bpm}
               onChange={handleBpmChange}
-              min={40}
-              max={200}
-              step={5}
+              min={BPM_MIN}
+              max={BPM_MAX}
+              step={BPM_STEP}
               disabled={isPlaying}
             />
             <span className="control-value">{song.bpm}</span>
@@ -365,63 +364,34 @@ export default function Home() {
               className={`notes-panel-btn ${allowedNotes !== null ? "active" : ""}`}
               onClick={() => setIsNotePanelOpen((prev) => !prev)}
             >
-              {allowedNotes !== null
-                ? `${allowedNotes.length} notes`
-                : "All notes"}
-              <span className="notes-panel-arrow">
-                {isNotePanelOpen ? "▲" : "▼"}
-              </span>
+              {allowedNotes !== null ? `${allowedNotes.length} notes` : "All notes"}
+              <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
             </button>
           </div>
         </div>
-        <button
-          className="undo-btn"
-          onClick={handleUndo}
-          disabled={history.length === 0}
-        >
+        <button className="undo-btn" onClick={handleUndo} disabled={history.length === 0}>
           Undo
         </button>
         <button className="reset-btn" onClick={handleReset}>
           Reset
         </button>
+        <button className="save-btn" onClick={() => setIsSaveModalOpen(true)}>
+          Save
+        </button>
+        <Link href="/songs" className="songs-nav-link">
+          みんなの曲
+        </Link>
       </header>
 
       {isNotePanelOpen && (
-        <div className="note-panel">
-          <div className="note-panel-header">
-            <div>
-              <span className="note-panel-title">Active notes</span>
-              {allowedNotes === null && (
-                <span className="note-panel-hint">Tap to exclude notes</span>
-              )}
-            </div>
-            {allowedNotes !== null && (
-              <button className="note-panel-reset" onClick={handleClearAllowedNotes}>
-                Show all
-              </button>
-            )}
-          </div>
-          <div className="note-panel-chips">
-            {rangeNotes.map((noteName) => {
-              const isActive = allowedNotes === null || allowedNotes.includes(noteName);
-              return (
-                <button
-                  key={noteName}
-                  className={`note-chip ${isActive ? "active" : ""}`}
-                  style={
-                    isActive
-                      ? { backgroundColor: colorForNote(noteName) }
-                      : { borderColor: colorForNote(noteName), color: colorForNote(noteName) }
-                  }
-                  onClick={() => handleNoteChipClick(noteName)}
-                >
-                  {noteName}
-                </button>
-              );
-            })}
-          </div>
-        </div>
+        <NotePanel
+          rangeNotes={rangeNotes}
+          allowedNotes={allowedNotes}
+          onNoteClick={handleNoteChipClick}
+          onClear={handleClearAllowedNotes}
+        />
       )}
+
       <main className="main">
         <div className="grid-container" ref={gridContainerRef}>
           <div className="labels grid">
@@ -460,6 +430,10 @@ export default function Home() {
           </div>
         </div>
       </main>
+
+      {isSaveModalOpen && (
+        <SaveModal song={song} onClose={() => setIsSaveModalOpen(false)} />
+      )}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import type { DrumId, InstrumentId, MelodyNote, NoteName, Song } from "@/core/types";
-import { DEFAULT_SONG } from "@/core/defaults";
+import { DEFAULT_SONG, BPM_MIN, BPM_MAX, BPM_STEP, HISTORY_LIMIT } from "@/core/defaults";
 import {
   addMelodyNote,
   adjustPitchBound,
@@ -19,10 +19,10 @@ import { colorForDrum, colorForNote } from "@/ui/color";
 import { buildNoteRows, buildRangeNotes, findMelodyNoteAt, getNotePosition } from "@/ui/grid";
 import { AudioEngine } from "@/audio/engine";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
+import { useLocale } from "@/hooks/useLocale";
 import { supabase } from "@/lib/supabase";
 import { SaveModal } from "./components/SaveModal";
 import { NotePanel } from "./components/NotePanel";
-import { BPM_MIN, BPM_MAX, BPM_STEP, HISTORY_LIMIT } from "@/core/defaults";
 
 const DRUM_ROWS: DrumId[] = ["hihat", "snare", "kick"];
 
@@ -34,6 +34,7 @@ const INSTRUMENTS: { id: InstrumentId; label: string }[] = [
 ];
 
 export default function Home() {
+  const { locale, t, toggleLocale } = useLocale();
   const [song, setSong] = useState<Song>(DEFAULT_SONG);
   const [history, setHistory] = useState<Song[]>([]);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -280,19 +281,19 @@ export default function Home() {
             onClick={handlePlay}
             disabled={isPlaying}
           >
-            Play
+            {t.play}
           </button>
           <button
             className={`transport-btn stop-btn ${!isPlaying ? "disabled" : ""}`}
             onClick={handleStop}
             disabled={!isPlaying}
           >
-            Stop
+            {t.stop}
           </button>
         </div>
         <div className="header-controls">
           <div className={`control-group ${isPlaying ? "disabled" : ""}`}>
-            <span className="control-label">Tempo</span>
+            <span className="control-label">{t.tempo}</span>
             <input
               type="range"
               className="control-slider"
@@ -306,7 +307,7 @@ export default function Home() {
             <span className="control-value">{song.bpm}</span>
           </div>
           <div className="control-group">
-            <span className="control-label">Sound</span>
+            <span className="control-label">{t.sound}</span>
             <div className="instrument-selector">
               {INSTRUMENTS.map(({ id, label }) => (
                 <button
@@ -320,7 +321,7 @@ export default function Home() {
             </div>
           </div>
           <div className="control-group range-control">
-            <span className="control-label">Range</span>
+            <span className="control-label">{t.range}</span>
             <div className="range-chips">
               <div className="range-chip">
                 <button
@@ -364,29 +365,33 @@ export default function Home() {
               className={`notes-panel-btn ${allowedNotes !== null ? "active" : ""}`}
               onClick={() => setIsNotePanelOpen((prev) => !prev)}
             >
-              {allowedNotes !== null ? `${allowedNotes.length} notes` : "All notes"}
+              {allowedNotes !== null ? t.nNotes(allowedNotes.length) : t.allNotes}
               <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
             </button>
           </div>
         </div>
         <button className="undo-btn" onClick={handleUndo} disabled={history.length === 0}>
-          Undo
+          {t.undo}
         </button>
         <button className="reset-btn" onClick={handleReset}>
-          Reset
+          {t.reset}
         </button>
         <button className="save-btn" onClick={() => setIsSaveModalOpen(true)}>
-          Save
+          {t.save}
         </button>
         <Link href="/songs" className="songs-nav-link">
-          みんなの曲
+          {t.songsLink}
         </Link>
+        <button className="locale-toggle" onClick={toggleLocale}>
+          {t.switchLocale}
+        </button>
       </header>
 
       {isNotePanelOpen && (
         <NotePanel
           rangeNotes={rangeNotes}
           allowedNotes={allowedNotes}
+          locale={locale}
           onNoteClick={handleNoteChipClick}
           onClear={handleClearAllowedNotes}
         />
@@ -432,7 +437,11 @@ export default function Home() {
       </main>
 
       {isSaveModalOpen && (
-        <SaveModal song={song} onClose={() => setIsSaveModalOpen(false)} />
+        <SaveModal
+          song={song}
+          locale={locale}
+          onClose={() => setIsSaveModalOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
+import { useLocale } from "@/hooks/useLocale";
 import type { Song } from "@/core/types";
+import type { Locale } from "@/lib/i18n";
+import { translations } from "@/lib/i18n";
 
 type FeedSong = {
   id: string;
@@ -22,17 +25,19 @@ const CARD_GRADIENTS = [
   "linear-gradient(135deg, #feca57, #48dbfb)",
 ];
 
-function timeAgo(dateStr: string): string {
+function timeAgo(dateStr: string, locale: Locale): string {
+  const t = translations[locale];
   const sec = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-  if (sec < 60) return "たったいま";
+  if (sec < 60) return t.justNow;
   const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}分まえ`;
+  if (min < 60) return t.minutesAgo(min);
   const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}時間まえ`;
-  return `${Math.floor(hr / 24)}日まえ`;
+  if (hr < 24) return t.hoursAgo(hr);
+  return t.daysAgo(Math.floor(hr / 24));
 }
 
 export default function SongsPage() {
+  const { locale, t, toggleLocale } = useLocale();
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -52,16 +57,19 @@ export default function SongsPage() {
     <div className="songs-page">
       <header className="songs-header">
         <Link href="/" className="songs-back-btn">
-          ← つくる
+          {t.backToCreate}
         </Link>
-        <h1 className="songs-heading">みんなの曲</h1>
+        <h1 className="songs-heading">{t.pageTitle}</h1>
+        <button className="locale-toggle" onClick={toggleLocale}>
+          {t.switchLocale}
+        </button>
       </header>
 
       <main className="songs-main">
         {loading ? (
-          <p className="songs-status">よみこみちゅう...</p>
+          <p className="songs-status">{t.loading}</p>
         ) : songs.length === 0 ? (
-          <p className="songs-status">まだ曲がありません。さいしょに保存してみよう！</p>
+          <p className="songs-status">{t.noSongs}</p>
         ) : (
           <div className="songs-grid">
             {songs.map((song, i) => (
@@ -73,9 +81,9 @@ export default function SongsPage() {
                 <div className="song-card-body">
                   <p className="song-card-title">{song.title}</p>
                   <p className="song-card-author">{song.author}</p>
-                  <p className="song-card-time">{timeAgo(song.created_at)}</p>
+                  <p className="song-card-time">{timeAgo(song.created_at, locale)}</p>
                   <Link href={`/?load=${song.id}`} className="song-card-play">
-                    あそぶ
+                    {t.playBtn}
                   </Link>
                 </div>
               </div>

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { supabase } from "@/lib/supabase";
+import type { Song } from "@/core/types";
+
+type FeedSong = {
+  id: string;
+  title: string;
+  author: string;
+  created_at: string;
+  song_data: Song;
+};
+
+const CARD_GRADIENTS = [
+  "linear-gradient(135deg, #ff6b6b, #feca57)",
+  "linear-gradient(135deg, #48dbfb, #a29bfe)",
+  "linear-gradient(135deg, #ff9ff3, #54a0ff)",
+  "linear-gradient(135deg, #00d2d3, #ff9f43)",
+  "linear-gradient(135deg, #5f27cd, #ff6b6b)",
+  "linear-gradient(135deg, #feca57, #48dbfb)",
+];
+
+function timeAgo(dateStr: string): string {
+  const sec = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (sec < 60) return "たったいま";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}分まえ`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}時間まえ`;
+  return `${Math.floor(hr / 24)}日まえ`;
+}
+
+export default function SongsPage() {
+  const [songs, setSongs] = useState<FeedSong[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase
+      .from("songs")
+      .select("id, title, author, created_at, song_data")
+      .order("created_at", { ascending: false })
+      .limit(50)
+      .then(({ data }) => {
+        setSongs((data as FeedSong[]) ?? []);
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <div className="songs-page">
+      <header className="songs-header">
+        <Link href="/" className="songs-back-btn">
+          ← つくる
+        </Link>
+        <h1 className="songs-heading">みんなの曲</h1>
+      </header>
+
+      <main className="songs-main">
+        {loading ? (
+          <p className="songs-status">よみこみちゅう...</p>
+        ) : songs.length === 0 ? (
+          <p className="songs-status">まだ曲がありません。さいしょに保存してみよう！</p>
+        ) : (
+          <div className="songs-grid">
+            {songs.map((song, i) => (
+              <div key={song.id} className="song-card">
+                <div
+                  className="song-card-art"
+                  style={{ background: CARD_GRADIENTS[i % CARD_GRADIENTS.length] }}
+                />
+                <div className="song-card-body">
+                  <p className="song-card-title">{song.title}</p>
+                  <p className="song-card-author">{song.author}</p>
+                  <p className="song-card-time">{timeAgo(song.created_at)}</p>
+                  <Link href={`/?load=${song.id}`} className="song-card-play">
+                    あそぶ
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -1,5 +1,10 @@
 import type { Song } from "./types";
 
+export const BPM_MIN = 40;
+export const BPM_MAX = 200;
+export const BPM_STEP = 5;
+export const HISTORY_LIMIT = 50;
+
 export const DEFAULT_SONG: Song = {
   version: 1,
   bpm: 100,

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import { translations } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
+
+const STORAGE_KEY = "beatbubble-locale";
+
+export function useLocale() {
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window === "undefined") return "ja";
+    return (localStorage.getItem(STORAGE_KEY) as Locale) ?? "ja";
+  });
+
+  const toggleLocale = () => {
+    const next: Locale = locale === "ja" ? "en" : "ja";
+    setLocale(next);
+    localStorage.setItem(STORAGE_KEY, next);
+  };
+
+  return { locale, t: translations[locale], toggleLocale };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,105 @@
+export type Locale = "en" | "ja";
+
+type Translations = {
+  // Transport
+  play: string;
+  stop: string;
+  // Controls
+  tempo: string;
+  sound: string;
+  range: string;
+  allNotes: string;
+  nNotes: (n: number) => string;
+  // Actions
+  undo: string;
+  reset: string;
+  save: string;
+  songsLink: string;
+  // Note panel
+  activeNotes: string;
+  tapToExclude: string;
+  showAll: string;
+  // Save modal
+  saveModalTitle: string;
+  titlePlaceholder: string;
+  authorPlaceholder: string;
+  cancel: string;
+  saving: string;
+  // Songs page
+  backToCreate: string;
+  pageTitle: string;
+  loading: string;
+  noSongs: string;
+  playBtn: string;
+  justNow: string;
+  minutesAgo: (n: number) => string;
+  hoursAgo: (n: number) => string;
+  daysAgo: (n: number) => string;
+  // Locale toggle label (the language you'll switch TO)
+  switchLocale: string;
+};
+
+export const translations: Record<Locale, Translations> = {
+  en: {
+    play: "Play",
+    stop: "Stop",
+    tempo: "Tempo",
+    sound: "Sound",
+    range: "Range",
+    allNotes: "All notes",
+    nNotes: (n) => `${n} notes`,
+    undo: "Undo",
+    reset: "Reset",
+    save: "Save",
+    songsLink: "Songs",
+    activeNotes: "Active notes",
+    tapToExclude: "Tap to exclude notes",
+    showAll: "Show all",
+    saveModalTitle: "Save Song",
+    titlePlaceholder: "Song title",
+    authorPlaceholder: "Your name",
+    cancel: "Cancel",
+    saving: "Saving...",
+    backToCreate: "← Create",
+    pageTitle: "Everyone's Songs",
+    loading: "Loading...",
+    noSongs: "No songs yet. Be the first to save one!",
+    playBtn: "Play",
+    justNow: "just now",
+    minutesAgo: (n) => `${n}m ago`,
+    hoursAgo: (n) => `${n}h ago`,
+    daysAgo: (n) => `${n}d ago`,
+    switchLocale: "日本語",
+  },
+  ja: {
+    play: "えんそう",
+    stop: "とめる",
+    tempo: "テンポ",
+    sound: "おと",
+    range: "おんいき",
+    allNotes: "ぜんぶのおと",
+    nNotes: (n) => `${n}このおと`,
+    undo: "もどす",
+    reset: "リセット",
+    save: "ほぞん",
+    songsLink: "みんなの曲",
+    activeNotes: "つかうおと",
+    tapToExclude: "のぞくおとをタップ",
+    showAll: "ぜんぶみせる",
+    saveModalTitle: "曲をほぞん",
+    titlePlaceholder: "きょくのなまえ",
+    authorPlaceholder: "あなたのなまえ",
+    cancel: "キャンセル",
+    saving: "ほぞんちゅう...",
+    backToCreate: "← つくる",
+    pageTitle: "みんなの曲",
+    loading: "よみこみちゅう...",
+    noSongs: "まだ曲がありません。さいしょに保存してみよう！",
+    playBtn: "あそぶ",
+    justNow: "たったいま",
+    minutesAgo: (n) => `${n}分まえ`,
+    hoursAgo: (n) => `${n}時間まえ`,
+    daysAgo: (n) => `${n}日まえ`,
+    switchLocale: "EN",
+  },
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(url, key);

--- a/src/ui/grid.ts
+++ b/src/ui/grid.ts
@@ -2,13 +2,11 @@ import type { MelodyNote, NoteName, Song } from "@/core/types";
 import { midiToNoteName, noteNameToMidi } from "@/core/utils";
 import { isAccidental } from "./color";
 
-// Always returns notes from the min–max range, ignoring allowedNotes.
-// Used to populate the note picker panel regardless of selection mode.
-export function buildRangeNotes(song: Song): NoteName[] {
-  const { minNote, maxNote, allowAccidentals } = song.constraints;
-  const minMidi = noteNameToMidi(minNote);
-  const maxMidi = noteNameToMidi(maxNote);
-
+function notesInMidiRange(
+  minMidi: number,
+  maxMidi: number,
+  allowAccidentals: boolean
+): NoteName[] {
   const notes: NoteName[] = [];
   for (let midi = maxMidi; midi >= minMidi; midi--) {
     const noteName = midiToNoteName(midi);
@@ -18,27 +16,29 @@ export function buildRangeNotes(song: Song): NoteName[] {
   return notes;
 }
 
+// Always returns notes from the min–max range, ignoring allowedNotes.
+// Used to populate the note picker panel regardless of selection mode.
+export function buildRangeNotes(song: Song): NoteName[] {
+  const { minNote, maxNote, allowAccidentals } = song.constraints;
+  return notesInMidiRange(
+    noteNameToMidi(minNote),
+    noteNameToMidi(maxNote),
+    allowAccidentals
+  );
+}
+
 export function buildNoteRows(song: Song): NoteName[] {
   const { minNote, maxNote, allowAccidentals, allowedNotes } = song.constraints;
 
   if (allowedNotes !== null) {
-    return [...allowedNotes].sort(
-      (a, b) => noteNameToMidi(b) - noteNameToMidi(a)
-    );
+    return [...allowedNotes].sort((a, b) => noteNameToMidi(b) - noteNameToMidi(a));
   }
 
-  const minMidi = noteNameToMidi(minNote);
-  const maxMidi = noteNameToMidi(maxNote);
-
-  const notes: NoteName[] = [];
-  for (let midi = maxMidi; midi >= minMidi; midi--) {
-    const noteName = midiToNoteName(midi);
-    if (!allowAccidentals && isAccidental(noteName)) {
-      continue;
-    }
-    notes.push(noteName);
-  }
-  return notes;
+  return notesInMidiRange(
+    noteNameToMidi(minNote),
+    noteNameToMidi(maxNote),
+    allowAccidentals
+  );
 }
 
 export function findMelodyNoteAt(


### PR DESCRIPTION
## Summary

- Supabase を使った曲の保存機能と SNS 風フィード（`/songs` ページ）を追加
- 保存した曲を URL パラメータ (`?load=<id>`) でエディタに読み込む機能
- 日本語/英語の切り替えトグル（localStorage で永続化）をエディタ・曲一覧両ページに追加
- SaveModal・NotePanel をコンポーネントとして切り出しリファクタリング
- ファビコン追加、不要な Next.js テンプレートファイルの削除

## Test plan

- [ ] 曲を作成して保存 → `/songs` ページに表示されることを確認
- [ ] 曲カードの「あそぶ」ボタン → エディタに曲が読み込まれて再生できることを確認
- [ ] 日本語/英語トグルが両ページで動作し、リロード後も設定が保持されることを確認
- [ ] 音符の配置・再生・ドラム・Undo が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)