### PR TITLE
ドレミ表記対応: 日本語ロケールで音名をソルフェージュ表示

### DIFF
--- a/src/app/components/NotePanel.tsx
+++ b/src/app/components/NotePanel.tsx
@@ -4,6 +4,7 @@ import type { NoteName } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
 import { colorForNote } from "@/ui/color";
+import { noteLabel } from "@/ui/noteLabel";
 
 interface Props {
   rangeNotes: NoteName[];
@@ -45,7 +46,7 @@ export function NotePanel({ rangeNotes, allowedNotes, locale, onNoteClick, onCle
               }
               onClick={() => onNoteClick(noteName)}
             >
-              {noteName}
+              {noteLabel(noteName, locale)}
             </button>
           );
         })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/core/ops";
 import { totalSteps } from "@/core/utils";
 import { colorForDrum, colorForNote } from "@/ui/color";
+import { noteLabel } from "@/ui/noteLabel";
 import { buildNoteRows, buildRangeNotes, findMelodyNoteAt, getNotePosition } from "@/ui/grid";
 import { AudioEngine } from "@/audio/engine";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
@@ -331,7 +332,7 @@ export default function Home() {
                 >
                   ◀
                 </button>
-                <span className="range-chip-value">{song.constraints.minNote}</span>
+                <span className="range-chip-value">{noteLabel(song.constraints.minNote, locale)}</span>
                 <button
                   className="range-chip-btn"
                   onClick={() => handlePitchBoundChange("min", "up")}
@@ -349,7 +350,7 @@ export default function Home() {
                 >
                   ◀
                 </button>
-                <span className="range-chip-value">{song.constraints.maxNote}</span>
+                <span className="range-chip-value">{noteLabel(song.constraints.maxNote, locale)}</span>
                 <button
                   className="range-chip-btn"
                   onClick={() => handlePitchBoundChange("max", "up")}
@@ -406,7 +407,7 @@ export default function Home() {
                   className="label-cell"
                   style={{ backgroundColor: colorForNote(noteName) }}
                 >
-                  {noteName}
+                  {noteLabel(noteName, locale)}
                 </div>
               </div>
             ))}

--- a/src/ui/noteLabel.ts
+++ b/src/ui/noteLabel.ts
@@ -1,0 +1,26 @@
+import type { NoteName } from "@/core/types";
+import type { Locale } from "@/lib/i18n";
+
+const SOLFEGE: Record<string, string> = {
+  C: "ド",
+  D: "レ",
+  E: "ミ",
+  F: "ファ",
+  G: "ソ",
+  A: "ラ",
+  B: "シ",
+};
+
+// Converts a NoteName ("C4", "F#3") into a display label.
+// Japanese locale uses solfège (ドレミ); English keeps scientific pitch notation.
+// NoteName remains the storage representation — this only affects display.
+export function noteLabel(note: NoteName, locale: Locale): string {
+  if (locale !== "ja") return note;
+  const match = note.match(/^([A-Ga-g])([#b]?)(-?\d+)$/);
+  if (!match) return note;
+  const [, letter, accidental, octave] = match;
+  const base = SOLFEGE[letter.toUpperCase()];
+  if (!base) return note;
+  const acc = accidental === "#" ? "♯" : accidental === "b" ? "♭" : "";
+  return `${base}${acc}${octave}`;
+}


### PR DESCRIPTION
## What

日本語ロケール時に、音名を ABC（C, D, E…）ではなくドレミ（ド, レ, ミ…）で表示するようにしました。

- **新規** `src/ui/noteLabel.ts` — `noteLabel(note, locale)` 表示用ヘルパー
  - `C→ド D→レ E→ミ F→ファ G→ソ A→ラ B→シ`、`#→♯`、`b→♭`
  - オクターブ番号は維持（例: `F#3 → ファ♯3`）
  - 英語ロケールは従来どおり ABC（scientific pitch notation）
- 適用箇所: 鍵盤ラベル列・音域チップ（min/max）・音符選択パネル（NotePanel）

## Why

教室向けツールとして、日本の音楽教育で馴染みのあるドレミ表記の方が分かりやすいため。

## Notes for reviewers

- **保存形式は不変**: NoteName 文字列（`"C4"` 等）はデータ表現として維持し、変換は表示レイヤーのみ。CLAUDE.md の「Pitch is represented as NoteName string」要件を遵守。
- 既存の i18n 設計（`useLocale` / ロケールトグル）に統合。🌐 ボタンで ja↔en 切り替え時に表記も追従。
- `pnpm lint` パス済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)