### PR TITLE
黒鍵（半音）表示の切り替え設定を追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -308,6 +308,46 @@ a {
   opacity: 0.6;
 }
 
+.accidentals-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.accidentals-btn::before {
+  content: "♯";
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+.accidentals-btn:hover {
+  background: var(--grid-line);
+}
+
+.accidentals-btn.active {
+  background: linear-gradient(135deg, #2c2c34, #4a4a55);
+  color: white;
+  border-color: transparent;
+}
+
+.accidentals-btn.active::before {
+  opacity: 1;
+}
+
+.accidentals-btn.active:hover {
+  opacity: 0.9;
+}
+
 /* Note Picker Panel */
 .note-panel {
   background: var(--header-bg);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   adjustPitchBound,
   clearAllowedNotes,
   removeMelodyNote,
+  setAllowAccidentals,
   setAllowedNotes,
   setMelodyNoteDuration,
   toggleAllowedNote,
@@ -199,6 +200,10 @@ export default function Home() {
     setSong((prev) => ({ ...prev, instrument }));
   };
 
+  const handleToggleAccidentals = () => {
+    setSong((prev) => setAllowAccidentals(prev, !prev.constraints.allowAccidentals));
+  };
+
   const handleNoteChipClick = useCallback(
     (noteName: NoteName) => {
       const current = song.constraints.allowedNotes;
@@ -360,6 +365,15 @@ export default function Home() {
                 </button>
               </div>
             </div>
+          </div>
+          <div className="control-group">
+            <button
+              className={`accidentals-btn ${song.constraints.allowAccidentals ? "active" : ""}`}
+              onClick={handleToggleAccidentals}
+              aria-pressed={song.constraints.allowAccidentals}
+            >
+              {t.blackKeys}
+            </button>
           </div>
           <div className="control-group">
             <button

--- a/src/core/ops.ts
+++ b/src/core/ops.ts
@@ -2,6 +2,7 @@ import type { DrumId, MelodyNote, NoteName, Song } from "./types";
 import { newId } from "./id";
 import {
   compareNotes,
+  isAccidental,
   normalizeDuration,
   noteNameToMidi,
   PITCH_RANGE_MAX,
@@ -200,6 +201,38 @@ export function adjustPitchBound(
       ...song.melody,
       notes: filteredNotes,
     },
+  };
+}
+
+export function setAllowAccidentals(song: Song, allow: boolean): Song {
+  if (song.constraints.allowAccidentals === allow) return song;
+
+  // Turning accidentals on only reveals more rows — nothing to clean up.
+  if (allow) {
+    return {
+      ...song,
+      constraints: { ...song.constraints, allowAccidentals: true },
+    };
+  }
+
+  // Turning off: drop melody notes on black keys and prune allowedNotes.
+  const filteredNotes = song.melody.notes.filter((n) => !isAccidental(n.note));
+
+  let newAllowedNotes = song.constraints.allowedNotes;
+  if (newAllowedNotes !== null) {
+    const filtered = newAllowedNotes.filter((n) => !isAccidental(n));
+    // Keep current selection if filtering would leave 0 notes.
+    newAllowedNotes = filtered.length > 0 ? filtered : newAllowedNotes;
+  }
+
+  return {
+    ...song,
+    constraints: {
+      ...song.constraints,
+      allowAccidentals: false,
+      allowedNotes: newAllowedNotes,
+    },
+    melody: { ...song.melody, notes: filteredNotes },
   };
 }
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -68,6 +68,10 @@ export function isWhiteKey(midi: number): boolean {
   return WHITE_KEYS.includes(midi % 12);
 }
 
+export function isAccidental(note: NoteName): boolean {
+  return note.includes("#") || note.includes("b");
+}
+
 export function transposeNoteName(
   note: NoteName,
   semitones: number,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -10,6 +10,7 @@ type Translations = {
   range: string;
   allNotes: string;
   nNotes: (n: number) => string;
+  blackKeys: string;
   // Actions
   undo: string;
   reset: string;
@@ -48,6 +49,7 @@ export const translations: Record<Locale, Translations> = {
     range: "Range",
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
+    blackKeys: "Black keys",
     undo: "Undo",
     reset: "Reset",
     save: "Save",
@@ -79,6 +81,7 @@ export const translations: Record<Locale, Translations> = {
     range: "おんいき",
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
+    blackKeys: "くろいけんばん",
     undo: "もどす",
     reset: "リセット",
     save: "ほぞん",

--- a/src/ui/color.ts
+++ b/src/ui/color.ts
@@ -24,7 +24,3 @@ export function colorForNote(noteName: NoteName): string {
 export function colorForDrum(drumId: string): string {
   return DRUM_COLORS[drumId] ?? "hsl(0, 0%, 50%)";
 }
-
-export function isAccidental(noteName: NoteName): boolean {
-  return noteName.includes("#") || noteName.includes("b");
-}

--- a/src/ui/grid.ts
+++ b/src/ui/grid.ts
@@ -1,6 +1,5 @@
 import type { MelodyNote, NoteName, Song } from "@/core/types";
-import { midiToNoteName, noteNameToMidi } from "@/core/utils";
-import { isAccidental } from "./color";
+import { isAccidental, midiToNoteName, noteNameToMidi } from "@/core/utils";
 
 function notesInMidiRange(
   minMidi: number,


### PR DESCRIPTION
## What

設定（ボタン）で黒鍵（半音）の表示・入力を切り替えられるようにしました。

- **UI トグル** 「くろいけんばん / Black keys」ボタンを音域コントロールの隣に追加（`aria-pressed` 付き、♯アイコン）
- データモデルに既存の `allowAccidentals` 制約を UI から操作可能に
- **オフ時のクリーンアップ**: 黒鍵上のメロディ音を削除し、`allowedNotes` からも半音を除外（音域変更時の既存パターンに準拠／全消し防止つき）

## Refactor

重複していた `isAccidental` 判定を **`core/utils.ts` に集約**（従来は `ui/color.ts` と `ops.ts` インラインの2箇所に重複）。`ui/grid.ts` のインポート元も `core/utils` に変更。

## Why

教室向けに、学年・用途に応じて半音を扱うかどうかを曲ごとに切り替えられるようにするため。

## Notes for reviewers

- `setAllowAccidentals` は `src/core/*` の純粋・不変の方針を維持（DOM/時刻/AudioContext 非依存）。
- トグルは他の制約系ハンドラ（音域変更・使用音選択）と同様に undo 履歴へは積まない方針で統一。
- グリッド行・音域チップ・NotePanel はいずれも `buildNoteRows`/`buildRangeNotes` 経由で `allowAccidentals` を参照するため、トグルで黒鍵行が自動的に出入りします。
- ラベルは既存のドレミ変換により `ド♯` のように表示されます。
- `pnpm lint` / `tsc --noEmit` パス済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)