### PR TITLE
ヘッダー整理: 曲設定を「⚙せってい」パネルに集約

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -653,6 +653,107 @@ a {
   transform: translateY(0);
 }
 
+/* Settings toggle + panel */
+.settings-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+  white-space: nowrap;
+}
+
+.settings-btn:hover {
+  background: var(--grid-line);
+}
+
+.settings-btn.active {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  border-color: transparent;
+}
+
+.settings-icon {
+  font-size: 15px;
+}
+
+.settings-arrow {
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+.settings-panel {
+  background: var(--header-bg);
+  padding: 14px 16px 16px;
+  border-bottom: 1px solid var(--grid-line);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: inset 0 4px 8px rgba(0, 0, 0, 0.04);
+}
+
+/* header-controls lives inside the settings panel now — neutralize the
+   old in-header responsive overrides (top border / order / width). */
+.settings-panel .header-controls {
+  order: 0;
+  width: auto;
+  flex: 1;
+  padding-top: 0;
+  margin-top: 0;
+  border-top: none;
+  gap: 16px;
+}
+
+.settings-danger {
+  display: flex;
+  align-items: center;
+  padding-top: 12px;
+  border-top: 1px dashed var(--grid-line);
+}
+
+.reset-confirm {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.reset-confirm-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.reset-btn.confirm {
+  background: linear-gradient(135deg, #ff6b6b, #ee5253);
+}
+
+.reset-cancel-btn {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.reset-cancel-btn:hover {
+  background: var(--grid-line);
+}
+
 /* Main content */
 .main {
   flex: 1;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,8 @@ export default function Home() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [playheadStep, setPlayheadStep] = useState<number | null>(null);
   const [isNotePanelOpen, setIsNotePanelOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const gridRef = useRef<HTMLDivElement>(null);
@@ -179,6 +181,7 @@ export default function Home() {
     handleStop();
     setSong(DEFAULT_SONG);
     setHistory([]);
+    setIsConfirmingReset(false);
   };
 
   const handleUndo = useCallback(() => {
@@ -297,99 +300,20 @@ export default function Home() {
             {t.stop}
           </button>
         </div>
-        <div className="header-controls">
-          <div className={`control-group ${isPlaying ? "disabled" : ""}`}>
-            <span className="control-label">{t.tempo}</span>
-            <input
-              type="range"
-              className="control-slider"
-              value={song.bpm}
-              onChange={handleBpmChange}
-              min={BPM_MIN}
-              max={BPM_MAX}
-              step={BPM_STEP}
-              disabled={isPlaying}
-            />
-            <span className="control-value">{song.bpm}</span>
-          </div>
-          <div className="control-group">
-            <span className="control-label">{t.sound}</span>
-            <div className="instrument-selector">
-              {INSTRUMENTS.map(({ id, label }) => (
-                <button
-                  key={id}
-                  className={`instrument-btn ${song.instrument === id ? "active" : ""}`}
-                  onClick={() => handleInstrumentChange(id)}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="control-group range-control">
-            <span className="control-label">{t.range}</span>
-            <div className="range-chips">
-              <div className="range-chip">
-                <button
-                  className="range-chip-btn"
-                  onClick={() => handlePitchBoundChange("min", "down")}
-                  aria-label="Lower minimum note"
-                >
-                  ◀
-                </button>
-                <span className="range-chip-value">{noteLabel(song.constraints.minNote, locale)}</span>
-                <button
-                  className="range-chip-btn"
-                  onClick={() => handlePitchBoundChange("min", "up")}
-                  aria-label="Raise minimum note"
-                >
-                  ▶
-                </button>
-              </div>
-              <span className="range-separator">–</span>
-              <div className="range-chip">
-                <button
-                  className="range-chip-btn"
-                  onClick={() => handlePitchBoundChange("max", "down")}
-                  aria-label="Lower maximum note"
-                >
-                  ◀
-                </button>
-                <span className="range-chip-value">{noteLabel(song.constraints.maxNote, locale)}</span>
-                <button
-                  className="range-chip-btn"
-                  onClick={() => handlePitchBoundChange("max", "up")}
-                  aria-label="Raise maximum note"
-                >
-                  ▶
-                </button>
-              </div>
-            </div>
-          </div>
-          <div className="control-group">
-            <button
-              className={`accidentals-btn ${song.constraints.allowAccidentals ? "active" : ""}`}
-              onClick={handleToggleAccidentals}
-              aria-pressed={song.constraints.allowAccidentals}
-            >
-              {t.blackKeys}
-            </button>
-          </div>
-          <div className="control-group">
-            <button
-              className={`notes-panel-btn ${allowedNotes !== null ? "active" : ""}`}
-              onClick={() => setIsNotePanelOpen((prev) => !prev)}
-            >
-              {allowedNotes !== null ? t.nNotes(allowedNotes.length) : t.allNotes}
-              <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
-            </button>
-          </div>
-        </div>
         <button className="undo-btn" onClick={handleUndo} disabled={history.length === 0}>
           {t.undo}
         </button>
-        <button className="reset-btn" onClick={handleReset}>
-          {t.reset}
+        <button
+          className={`settings-btn ${isSettingsOpen ? "active" : ""}`}
+          onClick={() => {
+            setIsSettingsOpen((prev) => !prev);
+            setIsConfirmingReset(false);
+          }}
+          aria-expanded={isSettingsOpen}
+        >
+          <span className="settings-icon" aria-hidden="true">⚙</span>
+          {t.settings}
+          <span className="settings-arrow">{isSettingsOpen ? "▲" : "▼"}</span>
         </button>
         <button className="save-btn" onClick={() => setIsSaveModalOpen(true)}>
           {t.save}
@@ -401,6 +325,119 @@ export default function Home() {
           {t.switchLocale}
         </button>
       </header>
+
+      {isSettingsOpen && (
+        <div className="settings-panel">
+          <div className="header-controls">
+            <div className={`control-group ${isPlaying ? "disabled" : ""}`}>
+              <span className="control-label">{t.tempo}</span>
+              <input
+                type="range"
+                className="control-slider"
+                value={song.bpm}
+                onChange={handleBpmChange}
+                min={BPM_MIN}
+                max={BPM_MAX}
+                step={BPM_STEP}
+                disabled={isPlaying}
+              />
+              <span className="control-value">{song.bpm}</span>
+            </div>
+            <div className="control-group">
+              <span className="control-label">{t.sound}</span>
+              <div className="instrument-selector">
+                {INSTRUMENTS.map(({ id, label }) => (
+                  <button
+                    key={id}
+                    className={`instrument-btn ${song.instrument === id ? "active" : ""}`}
+                    onClick={() => handleInstrumentChange(id)}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="control-group range-control">
+              <span className="control-label">{t.range}</span>
+              <div className="range-chips">
+                <div className="range-chip">
+                  <button
+                    className="range-chip-btn"
+                    onClick={() => handlePitchBoundChange("min", "down")}
+                    aria-label="Lower minimum note"
+                  >
+                    ◀
+                  </button>
+                  <span className="range-chip-value">{noteLabel(song.constraints.minNote, locale)}</span>
+                  <button
+                    className="range-chip-btn"
+                    onClick={() => handlePitchBoundChange("min", "up")}
+                    aria-label="Raise minimum note"
+                  >
+                    ▶
+                  </button>
+                </div>
+                <span className="range-separator">–</span>
+                <div className="range-chip">
+                  <button
+                    className="range-chip-btn"
+                    onClick={() => handlePitchBoundChange("max", "down")}
+                    aria-label="Lower maximum note"
+                  >
+                    ◀
+                  </button>
+                  <span className="range-chip-value">{noteLabel(song.constraints.maxNote, locale)}</span>
+                  <button
+                    className="range-chip-btn"
+                    onClick={() => handlePitchBoundChange("max", "up")}
+                    aria-label="Raise maximum note"
+                  >
+                    ▶
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div className="control-group">
+              <button
+                className={`accidentals-btn ${song.constraints.allowAccidentals ? "active" : ""}`}
+                onClick={handleToggleAccidentals}
+                aria-pressed={song.constraints.allowAccidentals}
+              >
+                {t.blackKeys}
+              </button>
+            </div>
+            <div className="control-group">
+              <button
+                className={`notes-panel-btn ${allowedNotes !== null ? "active" : ""}`}
+                onClick={() => setIsNotePanelOpen((prev) => !prev)}
+              >
+                {allowedNotes !== null ? t.nNotes(allowedNotes.length) : t.allNotes}
+                <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
+              </button>
+            </div>
+          </div>
+          <div className="settings-danger">
+            {isConfirmingReset ? (
+              <div className="reset-confirm">
+                <span className="reset-confirm-label">{t.resetConfirm}</span>
+                <button className="reset-btn confirm" onClick={handleReset}>
+                  {t.confirmYes}
+                </button>
+                <button
+                  className="reset-cancel-btn"
+                  onClick={() => setIsConfirmingReset(false)}
+                >
+                  {t.cancel}
+                </button>
+              </div>
+            ) : (
+              <button className="reset-btn" onClick={() => setIsConfirmingReset(true)}>
+                {t.reset}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {isNotePanelOpen && (
         <NotePanel

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -11,9 +11,12 @@ type Translations = {
   allNotes: string;
   nNotes: (n: number) => string;
   blackKeys: string;
+  settings: string;
   // Actions
   undo: string;
   reset: string;
+  resetConfirm: string;
+  confirmYes: string;
   save: string;
   songsLink: string;
   // Note panel
@@ -50,8 +53,11 @@ export const translations: Record<Locale, Translations> = {
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
     blackKeys: "Black keys",
+    settings: "Settings",
     undo: "Undo",
     reset: "Reset",
+    resetConfirm: "Clear everything?",
+    confirmYes: "Yes",
     save: "Save",
     songsLink: "Songs",
     activeNotes: "Active notes",
@@ -82,8 +88,11 @@ export const translations: Record<Locale, Translations> = {
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
     blackKeys: "くろいけんばん",
+    settings: "せってい",
     undo: "もどす",
     reset: "リセット",
+    resetConfirm: "ぜんぶけす？",
+    confirmYes: "はい",
     save: "ほぞん",
     songsLink: "みんなの曲",
     activeNotes: "つかうおと",


### PR DESCRIPTION
## What

肥大化したヘッダー（1本のバーに15要素以上）を整理し、使用頻度の低い「曲の設定」を開閉式の **⚙せってい** パネルに集約しました。

### トップバー（常時表示・7要素に削減）
`BeatBubble / えんそう / とめる / もどす / ⚙せってい / ほぞん / みんなの曲 / 🌐`

### ⚙せっていパネル（開閉式）
テンポ・おと(楽器)・おんいき・くろいけんばん・使う音 を集約。既存の NotePanel と同じスライド開閉パターンで一貫性を確保。

### もどす / リセット
- **もどす(Undo)**: 編集中に頻繁に使うのでトップバーに残置
- **リセット**: 破壊的操作のためパネル内に隔離し、「ぜんぶけす？ [はい] [キャンセル]」の確認ステップを追加（誤操作防止）

## Why

要素が増えるたびにヘッダーが横に圧縮されてごちゃつく構造だった。「常時必要な操作」と「最初に決めて以降あまり触らない設定」を分離し、子ども向け教室ツールとして主役（再生）を明確化。

## Changes
- `src/app/page.tsx` — ヘッダー再構成、設定パネル、リセット確認 state
- `src/app/globals.css` — `.settings-btn` / `.settings-panel` / リセット確認のスタイル
- `src/lib/i18n.ts` — `settings` / `resetConfirm` / `confirmYes` 文字列（ja/en）

## Verification
- `pnpm lint` / `tsc --noEmit` パス
- 実機プレビューで3状態（通常 / パネル展開 / リセット確認）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)