### PR TITLE
小節数（横の長さ）を増減できるようにする

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -518,6 +518,16 @@ a {
   background: var(--beat-line);
 }
 
+.range-chip-btn:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
+
+.range-chip-btn:disabled:hover {
+  background: transparent;
+  opacity: 0.2;
+}
+
 .range-chip-value {
   min-width: 32px;
   padding: 0 4px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import Link from "next/link";
 import type { DrumId, InstrumentId, MelodyNote, NoteName, Song } from "@/core/types";
-import { DEFAULT_SONG, BPM_MIN, BPM_MAX, BPM_STEP, HISTORY_LIMIT } from "@/core/defaults";
+import { DEFAULT_SONG, BPM_MIN, BPM_MAX, BPM_STEP, BARS_MIN, BARS_MAX, HISTORY_LIMIT } from "@/core/defaults";
 import {
   addMelodyNote,
   adjustPitchBound,
@@ -11,6 +11,7 @@ import {
   removeMelodyNote,
   setAllowAccidentals,
   setAllowedNotes,
+  setBars,
   setMelodyNoteDuration,
   toggleAllowedNote,
   toggleDrumHit,
@@ -197,6 +198,10 @@ export default function Home() {
 
   const handlePitchBoundChange = (bound: "min" | "max", direction: "up" | "down") => {
     setSong((prev) => adjustPitchBound(prev, bound, direction));
+  };
+
+  const handleBarsChange = (direction: "inc" | "dec") => {
+    setSong((prev) => setBars(prev, prev.bars + (direction === "inc" ? 1 : -1)));
   };
 
   const handleInstrumentChange = (instrument: InstrumentId) => {
@@ -395,6 +400,32 @@ export default function Home() {
                     ▶
                   </button>
                 </div>
+              </div>
+            </div>
+            <div
+              className={`control-group ${
+                isPlaying || song.constraints.barsLocked ? "disabled" : ""
+              }`}
+            >
+              <span className="control-label">{t.bars}</span>
+              <div className="range-chip">
+                <button
+                  className="range-chip-btn"
+                  onClick={() => handleBarsChange("dec")}
+                  disabled={isPlaying || song.constraints.barsLocked || song.bars <= BARS_MIN}
+                  aria-label="Fewer bars"
+                >
+                  ◀
+                </button>
+                <span className="range-chip-value">{song.bars}</span>
+                <button
+                  className="range-chip-btn"
+                  onClick={() => handleBarsChange("inc")}
+                  disabled={isPlaying || song.constraints.barsLocked || song.bars >= BARS_MAX}
+                  aria-label="More bars"
+                >
+                  ▶
+                </button>
               </div>
             </div>
             <div className="control-group">

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -3,6 +3,8 @@ import type { Song } from "./types";
 export const BPM_MIN = 40;
 export const BPM_MAX = 200;
 export const BPM_STEP = 5;
+export const BARS_MIN = 1;
+export const BARS_MAX = 8;
 export const HISTORY_LIMIT = 50;
 
 export const DEFAULT_SONG: Song = {

--- a/src/core/ops.ts
+++ b/src/core/ops.ts
@@ -1,6 +1,8 @@
 import type { DrumId, MelodyNote, NoteName, Song } from "./types";
+import { BARS_MAX, BARS_MIN } from "./defaults";
 import { newId } from "./id";
 import {
+  clamp,
   compareNotes,
   isAccidental,
   normalizeDuration,
@@ -201,6 +203,32 @@ export function adjustPitchBound(
       ...song.melody,
       notes: filteredNotes,
     },
+  };
+}
+
+export function setBars(song: Song, bars: number): Song {
+  const clamped = clamp(Math.round(bars), BARS_MIN, BARS_MAX);
+  if (clamped === song.bars) return song;
+
+  const newTotal = clamped * 4 * song.stepsPerBeat;
+
+  // Shrinking: drop notes that start past the new end, and clamp the
+  // duration of notes that now overrun it. (No-op when extending.)
+  const notes = song.melody.notes
+    .filter((n) => n.startStep < newTotal)
+    .map((n) => ({
+      ...n,
+      durationSteps: Math.min(n.durationSteps, newTotal - n.startStep),
+    }));
+
+  // Shrinking: drop drum hits past the new end.
+  const hits = song.drums.hits.filter((h) => h.step < newTotal);
+
+  return {
+    ...song,
+    bars: clamped,
+    melody: { ...song.melody, notes },
+    drums: { ...song.drums, hits },
   };
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,6 +8,7 @@ type Translations = {
   tempo: string;
   sound: string;
   range: string;
+  bars: string;
   allNotes: string;
   nNotes: (n: number) => string;
   blackKeys: string;
@@ -50,6 +51,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "Tempo",
     sound: "Sound",
     range: "Range",
+    bars: "Bars",
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
     blackKeys: "Black keys",
@@ -85,6 +87,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "テンポ",
     sound: "おと",
     range: "おんいき",
+    bars: "しょうせつ",
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
     blackKeys: "くろいけんばん",


### PR DESCRIPTION
Closes #17

## What

グリッドの横の長さ（小節数 `bars`）をユーザーが増減できるようにしました。授業で「4小節だけで作らせる」「もっと長い曲にする」など、用途に合わせて長さを調整できます。

- **設定パネルに ◀ N ▶ の小節ステッパー**を追加（「しょうせつ / Bars」）
- 範囲は **1〜8小節**（`BARS_MIN` / `BARS_MAX`）
- 再生中・`barsLocked` 時は変更不可
- **短縮時のクリーンアップ**: 新しい末尾を超えるメロディ音／ドラムを削除し、またぐノートの長さをクランプ

## How

`bars` は元から `Song` の一級フィールドで、グリッド列数・再生ループ長が `totalSteps = bars × 4 × stepsPerBeat` から導出されているため、`bars` を変えれば全体が自動でリフローします。追加したのは UI と短縮時の後処理のみ。

- `src/core/defaults.ts` — `BARS_MIN=1` / `BARS_MAX=8`
- `src/core/ops.ts` — 純粋 op `setBars()`（clamp＋短縮時のノート/ドラム整理、`adjustPitchBound` のパターン踏襲）
- `src/app/page.tsx` — `handleBarsChange` ＋ 設定パネル内ステッパー
- `src/lib/i18n.ts` — 「しょうせつ / Bars」
- `src/app/globals.css` — 上限/下限で無効化したチップボタンの `:disabled` スタイル

## Verification（実機プレビューで確認）

- ◀▶ で小節を増減 → グリッド幅と列数が連動（1小節=16セル）
- 上限8で ▶ 無効化（128セル、横スクロール可）／下限1で ◀ 無効化（16セル）
- **末尾にノートを置いて短縮 → 範囲外ノートが消える**ことを確認
- `pnpm lint` / `tsc --noEmit` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)