### PR TITLE
モバイルヘッダーのレイアウト崩れを修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,15 +129,6 @@ a {
     padding: 12px 16px;
   }
 
-  .header-controls {
-    order: 3;
-    width: 100%;
-    justify-content: flex-start;
-    padding-top: 8px;
-    border-top: 1px solid var(--grid-line);
-    margin-top: 4px;
-  }
-
   .control-slider::-webkit-slider-thumb {
     width: 22px;
     height: 22px;
@@ -161,24 +152,35 @@ a {
     width: 100%;
   }
 
+  /* Header order on mobile: title, then primary transport, then
+     secondary actions. (header-controls + reset now live in the
+     settings panel, so they no longer participate in this row.) */
   .transport {
-    order: 2;
-  }
-
-  .reset-btn {
-    order: 3;
-    margin-left: 0;
-    padding: 8px 12px;
-    font-size: 13px;
-  }
-
-  .header-controls {
-    order: 4;
+    order: 1;
     width: 100%;
-    padding-top: 10px;
-    border-top: 1px solid var(--grid-line);
-    margin-top: 4px;
-    gap: 8px;
+  }
+
+  /* .header prefix raises specificity above the base
+     `.undo-btn { margin-left: auto }` defined later in the file. */
+  .header .undo-btn {
+    order: 2;
+    margin-left: 0;
+  }
+
+  .settings-btn {
+    order: 3;
+  }
+
+  .save-btn {
+    order: 4;
+  }
+
+  .songs-nav-link {
+    order: 5;
+  }
+
+  .locale-toggle {
+    order: 6;
   }
 
   .control-group {
@@ -201,6 +203,7 @@ a {
   }
 
   .transport-btn {
+    flex: 1;
     padding: 10px 16px;
     font-size: 13px;
     min-height: 44px;


### PR DESCRIPTION
## What

モバイル幅で、主役の「えんそう／とめる（再生/停止）」が設定・保存・ナビより下に押し出されていた問題を修正しました。

**Before（モバイル）**: タイトル → もどす/せってい/ほぞん → みんなの曲/EN → **えんそう/とめるが最下段**
**After（モバイル）**: タイトル → **えんそう/とめる（横幅いっぱい・主役）** → もどす/せってい/ほぞん → みんなの曲/EN

## Why

ヘッダー再構成（PR #16）で `reset` と各コントロールを設定パネルへ移したが、モバイル/タブレットの media query が旧構造前提のままだった。`.transport { order: 2 }` が残っていたため、`order:0` の他ボタン群より後ろに回り、再生ボタンが最下段に沈んでいた。あわせて、ヘッダーから消えた要素を指す死にルール（`.header-controls` / `.reset-btn` の order・width・border-top）も残存していた。

## Changes（CSSのみ）
- **モバイル**: ヘッダーの順序を明示（タイトル → 横幅いっぱいの transport → セカンダリ操作）。`transport-btn` を `flex:1` で全幅化し再生/停止を主役に。
- undo の `margin-left:auto`（ファイル後方の base 規則）を `.header .undo-btn` で詳細度を上げて打ち消し、セカンダリ操作を左詰めに。
- タブレット/モバイルの media query から死んだ `.header-controls` 上書きを削除。

## Verification
- 実機プレビューで **375 / 768 / 1280px** を確認
- モバイル：再生/停止が全幅で最上段、もどすは左詰め
- タブレット・デスクトップ：従来どおり単一行（操作群は右寄せ）— 変化なし
- `pnpm lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)