### PR TITLE
長さの単位を「ブロック（拍）」に変更し、1クリック1ブロック増減に

### DIFF
--- a/src/app/components/SettingsPanel.tsx
+++ b/src/app/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { InstrumentId, Song } from "@/core/types";
 import type { Locale, Translations } from "@/lib/i18n";
-import { BPM_MIN, BPM_MAX, BPM_STEP, BARS_MIN, BARS_MAX } from "@/core/defaults";
+import { BPM_MIN, BPM_MAX, BPM_STEP, BLOCKS_MIN, BLOCKS_MAX } from "@/core/defaults";
 import { noteLabel } from "@/ui/noteLabel";
 
 const INSTRUMENTS: { id: InstrumentId; label: string }[] = [
@@ -21,7 +21,7 @@ interface Props {
   isConfirmingReset: boolean;
   onBpmChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPitchBoundChange: (bound: "min" | "max", direction: "up" | "down") => void;
-  onBarsChange: (direction: "inc" | "dec") => void;
+  onBlocksChange: (direction: "inc" | "dec") => void;
   onInstrumentChange: (instrument: InstrumentId) => void;
   onToggleAccidentals: () => void;
   onToggleNotePanel: () => void;
@@ -39,7 +39,7 @@ export function SettingsPanel({
   isConfirmingReset,
   onBpmChange,
   onPitchBoundChange,
-  onBarsChange,
+  onBlocksChange,
   onInstrumentChange,
   onToggleAccidentals,
   onToggleNotePanel,
@@ -48,7 +48,7 @@ export function SettingsPanel({
   onCancelReset,
 }: Props) {
   const { constraints } = song;
-  const barsDisabled = isPlaying || constraints.barsLocked;
+  const blocksDisabled = isPlaying || constraints.blocksLocked;
 
   return (
     <div className="settings-panel">
@@ -121,23 +121,23 @@ export function SettingsPanel({
             </div>
           </div>
         </div>
-        <div className={`control-group ${barsDisabled ? "disabled" : ""}`}>
-          <span className="control-label">{t.bars}</span>
+        <div className={`control-group ${blocksDisabled ? "disabled" : ""}`}>
+          <span className="control-label">{t.blocks}</span>
           <div className="range-chip">
             <button
               className="range-chip-btn"
-              onClick={() => onBarsChange("dec")}
-              disabled={barsDisabled || song.bars <= BARS_MIN}
-              aria-label="Fewer bars"
+              onClick={() => onBlocksChange("dec")}
+              disabled={blocksDisabled || song.blocks <= BLOCKS_MIN}
+              aria-label="Fewer blocks"
             >
               ◀
             </button>
-            <span className="range-chip-value">{song.bars}</span>
+            <span className="range-chip-value">{song.blocks}</span>
             <button
               className="range-chip-btn"
-              onClick={() => onBarsChange("inc")}
-              disabled={barsDisabled || song.bars >= BARS_MAX}
-              aria-label="More bars"
+              onClick={() => onBlocksChange("inc")}
+              disabled={blocksDisabled || song.blocks >= BLOCKS_MAX}
+              aria-label="More blocks"
             >
               ▶
             </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import type { DrumId, InstrumentId, NoteName, Song } from "@/core/types";
+import type { DrumId, InstrumentId, NoteName } from "@/core/types";
 import {
   addMelodyNote,
   adjustPitchBound,
@@ -9,11 +9,12 @@ import {
   removeMelodyNote,
   setAllowAccidentals,
   setAllowedNotes,
-  setBars,
+  setBlocks,
   setMelodyNoteDuration,
   toggleAllowedNote,
   toggleDrumHit,
 } from "@/core/ops";
+import { migrateSong } from "@/core/legacy";
 import { buildRangeNotes, findMelodyNoteAt } from "@/ui/grid";
 import { AudioEngine } from "@/audio/engine";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
@@ -53,7 +54,7 @@ export default function Home() {
       .single()
       .then(({ data }) => {
         if (data?.song_data) {
-          setSong(data.song_data as Song);
+          setSong(migrateSong(data.song_data));
           window.history.replaceState({}, "", "/");
         }
       });
@@ -171,8 +172,8 @@ export default function Home() {
     setSong((prev) => adjustPitchBound(prev, bound, direction));
   };
 
-  const handleBarsChange = (direction: "inc" | "dec") => {
-    setSong((prev) => setBars(prev, prev.bars + (direction === "inc" ? 1 : -1)));
+  const handleBlocksChange = (direction: "inc" | "dec") => {
+    setSong((prev) => setBlocks(prev, prev.blocks + (direction === "inc" ? 1 : -1)));
   };
 
   const handleInstrumentChange = (instrument: InstrumentId) => {
@@ -239,7 +240,7 @@ export default function Home() {
           isConfirmingReset={isConfirmingReset}
           onBpmChange={handleBpmChange}
           onPitchBoundChange={handlePitchBoundChange}
-          onBarsChange={handleBarsChange}
+          onBlocksChange={handleBlocksChange}
           onInstrumentChange={handleInstrumentChange}
           onToggleAccidentals={handleToggleAccidentals}
           onToggleNotePanel={() => setIsNotePanelOpen((prev) => !prev)}

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -3,15 +3,16 @@ import type { Song } from "./types";
 export const BPM_MIN = 40;
 export const BPM_MAX = 200;
 export const BPM_STEP = 5;
-export const BARS_MIN = 1;
-export const BARS_MAX = 8;
+// Grid length in blocks (1 block = 1 beat = stepsPerBeat cells).
+export const BLOCKS_MIN = 1;
+export const BLOCKS_MAX = 32;
 export const HISTORY_LIMIT = 50;
 
 export const DEFAULT_SONG: Song = {
-  version: 1,
+  version: 2,
   bpm: 100,
   stepsPerBeat: 4,
-  bars: 4,
+  blocks: 16,
   instrument: "piano",
   constraints: {
     minNote: "C4",
@@ -19,7 +20,7 @@ export const DEFAULT_SONG: Song = {
     allowAccidentals: false,
     allowedNotes: null,
     tempoLocked: false,
-    barsLocked: false,
+    blocksLocked: false,
     drumsEnabled: true,
   },
   melody: { notes: [] },

--- a/src/core/legacy.ts
+++ b/src/core/legacy.ts
@@ -3,10 +3,12 @@ import { newId } from "./id";
 import { BLOCKS_MAX, BLOCKS_MIN, DEFAULT_SONG } from "./defaults";
 import { clamp } from "./utils";
 
+// v1 fixed 4/4 time, so each bar spanned 4 beats — i.e. 4 blocks.
+const V1_BLOCKS_PER_BAR = 4;
+
 // Migrate a persisted song to the current model.
-// v1 measured length in `bars` (1 bar = 4 beats = 4 blocks); v2 measures
-// length directly in `blocks`. Total step count is unchanged, so notes
-// stay in range.
+// v1 measured length in `bars`; v2 measures length directly in `blocks`.
+// Total step count is unchanged, so notes stay in range.
 export function migrateSong(raw: unknown): Song {
   const data = raw as Record<string, unknown>;
 
@@ -14,8 +16,10 @@ export function migrateSong(raw: unknown): Song {
     return data as unknown as Song;
   }
 
-  const bars = typeof data.bars === "number" ? data.bars : DEFAULT_SONG.blocks / 4;
-  const blocks = clamp(Math.round(bars * 4), BLOCKS_MIN, BLOCKS_MAX);
+  const blocks =
+    typeof data.bars === "number"
+      ? clamp(Math.round(data.bars * V1_BLOCKS_PER_BAR), BLOCKS_MIN, BLOCKS_MAX)
+      : DEFAULT_SONG.blocks;
 
   const { barsLocked, ...restConstraints } =
     (data.constraints as { barsLocked?: boolean }) ?? {};

--- a/src/core/legacy.ts
+++ b/src/core/legacy.ts
@@ -1,6 +1,38 @@
 import type { DrumId, InstrumentId, Song } from "./types";
 import { newId } from "./id";
-import { DEFAULT_SONG } from "./defaults";
+import { BLOCKS_MAX, BLOCKS_MIN, DEFAULT_SONG } from "./defaults";
+import { clamp } from "./utils";
+
+// Migrate a persisted song to the current model.
+// v1 measured length in `bars` (1 bar = 4 beats = 4 blocks); v2 measures
+// length directly in `blocks`. Total step count is unchanged, so notes
+// stay in range.
+export function migrateSong(raw: unknown): Song {
+  const data = raw as Record<string, unknown>;
+
+  if (data.version === 2 && typeof data.blocks === "number") {
+    return data as unknown as Song;
+  }
+
+  const bars = typeof data.bars === "number" ? data.bars : DEFAULT_SONG.blocks / 4;
+  const blocks = clamp(Math.round(bars * 4), BLOCKS_MIN, BLOCKS_MAX);
+
+  const { barsLocked, ...restConstraints } =
+    (data.constraints as { barsLocked?: boolean }) ?? {};
+  const next = { ...data };
+  delete next.bars;
+
+  return {
+    ...next,
+    version: 2,
+    blocks,
+    constraints: {
+      ...DEFAULT_SONG.constraints,
+      ...restConstraints,
+      blocksLocked: barsLocked ?? false,
+    },
+  } as unknown as Song;
+}
 
 type LegacyCell = {
   note: string;
@@ -33,15 +65,15 @@ function mapInstrument(instrument?: string): InstrumentId {
 
 export function fromLegacyMusicData(musicData: LegacyMusicData): Song {
   const stepsPerBeat = 4;
-  const bars = Math.ceil(musicData.beats / (stepsPerBeat * 4));
+  const blocks = Math.max(1, Math.ceil(musicData.beats / stepsPerBeat));
   const bpm = musicData.bpm ?? 100;
   const instrument = mapInstrument(musicData.instrument);
 
   const song: Song = {
-    version: 1,
+    version: 2,
     bpm,
     stepsPerBeat,
-    bars,
+    blocks,
     instrument,
     constraints: { ...DEFAULT_SONG.constraints },
     melody: { notes: [] },

--- a/src/core/ops.ts
+++ b/src/core/ops.ts
@@ -1,5 +1,5 @@
 import type { DrumId, MelodyNote, NoteName, Song } from "./types";
-import { BARS_MAX, BARS_MIN } from "./defaults";
+import { BLOCKS_MAX, BLOCKS_MIN } from "./defaults";
 import { newId } from "./id";
 import {
   clamp,
@@ -206,11 +206,11 @@ export function adjustPitchBound(
   };
 }
 
-export function setBars(song: Song, bars: number): Song {
-  const clamped = clamp(Math.round(bars), BARS_MIN, BARS_MAX);
-  if (clamped === song.bars) return song;
+export function setBlocks(song: Song, blocks: number): Song {
+  const clamped = clamp(Math.round(blocks), BLOCKS_MIN, BLOCKS_MAX);
+  if (clamped === song.blocks) return song;
 
-  const newTotal = clamped * 4 * song.stepsPerBeat;
+  const newTotal = clamped * song.stepsPerBeat;
 
   // Shrinking: drop notes that start past the new end, and clamp the
   // duration of notes that now overrun it. (No-op when extending.)
@@ -226,7 +226,7 @@ export function setBars(song: Song, bars: number): Song {
 
   return {
     ...song,
-    bars: clamped,
+    blocks: clamped,
     melody: { ...song.melody, notes },
     drums: { ...song.drums, hits },
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,15 +23,17 @@ export type Constraints = {
   allowAccidentals: boolean;
   allowedNotes: NoteName[] | null;
   tempoLocked: boolean;
-  barsLocked: boolean;
+  blocksLocked: boolean;
   drumsEnabled: boolean;
 };
 
 export type Song = {
-  version: 1;
+  version: 2;
   bpm: number;
   stepsPerBeat: number;
-  bars: number;
+  // Grid length in blocks. One block = one beat = `stepsPerBeat` cells,
+  // i.e. one visible group bounded by the beat-start lines.
+  blocks: number;
   instrument: InstrumentId;
   constraints: Constraints;
   melody: { notes: MelodyNote[] };

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,7 +5,7 @@ export function clamp(n: number, min: number, max: number): number {
 }
 
 export function totalSteps(song: Song): number {
-  return song.bars * 4 * song.stepsPerBeat;
+  return song.blocks * song.stepsPerBeat;
 }
 
 export function normalizeDuration(

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,7 +8,7 @@ export type Translations = {
   tempo: string;
   sound: string;
   range: string;
-  bars: string;
+  blocks: string;
   allNotes: string;
   nNotes: (n: number) => string;
   blackKeys: string;
@@ -51,7 +51,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "Tempo",
     sound: "Sound",
     range: "Range",
-    bars: "Bars",
+    blocks: "Blocks",
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
     blackKeys: "Black keys",
@@ -87,7 +87,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "テンポ",
     sound: "おと",
     range: "おんいき",
-    bars: "しょうせつ",
+    blocks: "ブロック",
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
     blackKeys: "くろいけんばん",


### PR DESCRIPTION
## What

長さコントロールが「小節」単位だったため、1クリックで4ブロック（1小節＝4拍）増減していました。単位を **ブロック（＝1拍＝`stepsPerBeat`マス＝beat-start線で区切られる見えるブロック）** に変更し、**1クリック＝1ブロック増減**にしました。

## データモデル（Song v2）

- `bars` → `blocks`、`totalSteps = blocks × stepsPerBeat`（旧 `bars × 4 × stepsPerBeat`）
- `constraints.barsLocked` → `blocksLocked`
- `BARS_MIN/MAX (1..8)` → `BLOCKS_MIN/MAX (1..32)`、デフォルト 16 ブロック（＝従来の4小節と同じ長さ）
- `setBars` → `setBlocks`

## 互換性（保存済み曲の移行）

- `migrateSong()` を追加し、`?load=` で読み込む際に v1（bars）曲を自動移行：`blocks = bars × 4`。**総ステップ数は不変**なので音は範囲外に出ません。`barsLocked → blocksLocked` も写します。
- 新規保存は v2 形式で書き込まれます。

## UI

ラベル「しょうせつ / Bars」→「ブロック / Blocks」。

## 検証（実機プレビュー）

- デフォルト 16 ブロック（64セル）、ラベル「ブロック」
- **+1クリック = +1ブロック（+4セル）**（16→17 で 64→68セル）
- 最小1（4セル）/最大32（128セル）で境界無効化
- **実保存曲（bars=4）を読み込み → 16ブロックに移行、メロディ95＋ドラム98ノート全健在・長さ維持・エラーなし**
- `pnpm build` / `lint` / `tsc` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)