### PR TITLE
修正: 長さを1マス（セル）単位で増減できるように

### DIFF
--- a/src/app/components/SettingsPanel.tsx
+++ b/src/app/components/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { InstrumentId, Song } from "@/core/types";
 import type { Locale, Translations } from "@/lib/i18n";
-import { BPM_MIN, BPM_MAX, BPM_STEP, BLOCKS_MIN, BLOCKS_MAX } from "@/core/defaults";
+import { BPM_MIN, BPM_MAX, BPM_STEP, CELLS_MIN, CELLS_MAX } from "@/core/defaults";
 import { noteLabel } from "@/ui/noteLabel";
 
 const INSTRUMENTS: { id: InstrumentId; label: string }[] = [
@@ -21,7 +21,7 @@ interface Props {
   isConfirmingReset: boolean;
   onBpmChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPitchBoundChange: (bound: "min" | "max", direction: "up" | "down") => void;
-  onBlocksChange: (direction: "inc" | "dec") => void;
+  onCellsChange: (direction: "inc" | "dec") => void;
   onInstrumentChange: (instrument: InstrumentId) => void;
   onToggleAccidentals: () => void;
   onToggleNotePanel: () => void;
@@ -39,7 +39,7 @@ export function SettingsPanel({
   isConfirmingReset,
   onBpmChange,
   onPitchBoundChange,
-  onBlocksChange,
+  onCellsChange,
   onInstrumentChange,
   onToggleAccidentals,
   onToggleNotePanel,
@@ -48,7 +48,7 @@ export function SettingsPanel({
   onCancelReset,
 }: Props) {
   const { constraints } = song;
-  const blocksDisabled = isPlaying || constraints.blocksLocked;
+  const lengthDisabled = isPlaying || constraints.lengthLocked;
 
   return (
     <div className="settings-panel">
@@ -121,23 +121,23 @@ export function SettingsPanel({
             </div>
           </div>
         </div>
-        <div className={`control-group ${blocksDisabled ? "disabled" : ""}`}>
-          <span className="control-label">{t.blocks}</span>
+        <div className={`control-group ${lengthDisabled ? "disabled" : ""}`}>
+          <span className="control-label">{t.cells}</span>
           <div className="range-chip">
             <button
               className="range-chip-btn"
-              onClick={() => onBlocksChange("dec")}
-              disabled={blocksDisabled || song.blocks <= BLOCKS_MIN}
-              aria-label="Fewer blocks"
+              onClick={() => onCellsChange("dec")}
+              disabled={lengthDisabled || song.cells <= CELLS_MIN}
+              aria-label="Fewer cells"
             >
               ◀
             </button>
-            <span className="range-chip-value">{song.blocks}</span>
+            <span className="range-chip-value">{song.cells}</span>
             <button
               className="range-chip-btn"
-              onClick={() => onBlocksChange("inc")}
-              disabled={blocksDisabled || song.blocks >= BLOCKS_MAX}
-              aria-label="More blocks"
+              onClick={() => onCellsChange("inc")}
+              disabled={lengthDisabled || song.cells >= CELLS_MAX}
+              aria-label="More cells"
             >
               ▶
             </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import {
   removeMelodyNote,
   setAllowAccidentals,
   setAllowedNotes,
-  setBlocks,
+  setCells,
   setMelodyNoteDuration,
   toggleAllowedNote,
   toggleDrumHit,
@@ -172,8 +172,8 @@ export default function Home() {
     setSong((prev) => adjustPitchBound(prev, bound, direction));
   };
 
-  const handleBlocksChange = (direction: "inc" | "dec") => {
-    setSong((prev) => setBlocks(prev, prev.blocks + (direction === "inc" ? 1 : -1)));
+  const handleCellsChange = (direction: "inc" | "dec") => {
+    setSong((prev) => setCells(prev, prev.cells + (direction === "inc" ? 1 : -1)));
   };
 
   const handleInstrumentChange = (instrument: InstrumentId) => {
@@ -240,7 +240,7 @@ export default function Home() {
           isConfirmingReset={isConfirmingReset}
           onBpmChange={handleBpmChange}
           onPitchBoundChange={handlePitchBoundChange}
-          onBlocksChange={handleBlocksChange}
+          onCellsChange={handleCellsChange}
           onInstrumentChange={handleInstrumentChange}
           onToggleAccidentals={handleToggleAccidentals}
           onToggleNotePanel={() => setIsNotePanelOpen((prev) => !prev)}

--- a/src/core/defaults.ts
+++ b/src/core/defaults.ts
@@ -3,16 +3,17 @@ import type { Song } from "./types";
 export const BPM_MIN = 40;
 export const BPM_MAX = 200;
 export const BPM_STEP = 5;
-// Grid length in blocks (1 block = 1 beat = stepsPerBeat cells).
-export const BLOCKS_MIN = 1;
-export const BLOCKS_MAX = 32;
+// Grid length as a number of cells (columns). One click of the length
+// control adds/removes a single cell.
+export const CELLS_MIN = 4;
+export const CELLS_MAX = 128;
 export const HISTORY_LIMIT = 50;
 
 export const DEFAULT_SONG: Song = {
-  version: 2,
+  version: 3,
   bpm: 100,
   stepsPerBeat: 4,
-  blocks: 16,
+  cells: 64,
   instrument: "piano",
   constraints: {
     minNote: "C4",
@@ -20,7 +21,7 @@ export const DEFAULT_SONG: Song = {
     allowAccidentals: false,
     allowedNotes: null,
     tempoLocked: false,
-    blocksLocked: false,
+    lengthLocked: false,
     drumsEnabled: true,
   },
   melody: { notes: [] },

--- a/src/core/legacy.ts
+++ b/src/core/legacy.ts
@@ -1,39 +1,53 @@
 import type { DrumId, InstrumentId, Song } from "./types";
 import { newId } from "./id";
-import { BLOCKS_MAX, BLOCKS_MIN, DEFAULT_SONG } from "./defaults";
+import { CELLS_MAX, CELLS_MIN, DEFAULT_SONG } from "./defaults";
 import { clamp } from "./utils";
 
-// v1 fixed 4/4 time, so each bar spanned 4 beats — i.e. 4 blocks.
-const V1_BLOCKS_PER_BAR = 4;
+// v1 fixed 4/4 time: each bar spanned 4 beats.
+const V1_BEATS_PER_BAR = 4;
 
-// Migrate a persisted song to the current model.
-// v1 measured length in `bars`; v2 measures length directly in `blocks`.
-// Total step count is unchanged, so notes stay in range.
+// Migrate a persisted song to the current model (length measured in cells).
+// Older versions measured length differently:
+//   v1: `bars`   -> cells = bars * 4 * stepsPerBeat
+//   v2: `blocks` -> cells = blocks * stepsPerBeat
+// The total cell count is preserved, so notes stay in range.
 export function migrateSong(raw: unknown): Song {
   const data = raw as Record<string, unknown>;
 
-  if (data.version === 2 && typeof data.blocks === "number") {
+  if (data.version === 3 && typeof data.cells === "number") {
     return data as unknown as Song;
   }
 
-  const blocks =
-    typeof data.bars === "number"
-      ? clamp(Math.round(data.bars * V1_BLOCKS_PER_BAR), BLOCKS_MIN, BLOCKS_MAX)
-      : DEFAULT_SONG.blocks;
+  const stepsPerBeat =
+    typeof data.stepsPerBeat === "number" ? data.stepsPerBeat : DEFAULT_SONG.stepsPerBeat;
 
-  const { barsLocked, ...restConstraints } =
-    (data.constraints as { barsLocked?: boolean }) ?? {};
+  let cells: number;
+  if (typeof data.cells === "number") {
+    cells = data.cells;
+  } else if (typeof data.blocks === "number") {
+    cells = data.blocks * stepsPerBeat;
+  } else if (typeof data.bars === "number") {
+    cells = data.bars * V1_BEATS_PER_BAR * stepsPerBeat;
+  } else {
+    cells = DEFAULT_SONG.cells;
+  }
+  cells = clamp(Math.round(cells), CELLS_MIN, CELLS_MAX);
+
+  // Length-lock was named barsLocked (v1) then blocksLocked (v2).
+  const { barsLocked, blocksLocked, lengthLocked, ...restConstraints } =
+    (data.constraints as Record<string, unknown>) ?? {};
   const next = { ...data };
   delete next.bars;
+  delete next.blocks;
 
   return {
     ...next,
-    version: 2,
-    blocks,
+    version: 3,
+    cells,
     constraints: {
       ...DEFAULT_SONG.constraints,
       ...restConstraints,
-      blocksLocked: barsLocked ?? false,
+      lengthLocked: (lengthLocked ?? blocksLocked ?? barsLocked ?? false) === true,
     },
   } as unknown as Song;
 }
@@ -69,15 +83,15 @@ function mapInstrument(instrument?: string): InstrumentId {
 
 export function fromLegacyMusicData(musicData: LegacyMusicData): Song {
   const stepsPerBeat = 4;
-  const blocks = Math.max(1, Math.ceil(musicData.beats / stepsPerBeat));
+  const cells = clamp(Math.round(musicData.beats), CELLS_MIN, CELLS_MAX);
   const bpm = musicData.bpm ?? 100;
   const instrument = mapInstrument(musicData.instrument);
 
   const song: Song = {
-    version: 2,
+    version: 3,
     bpm,
     stepsPerBeat,
-    blocks,
+    cells,
     instrument,
     constraints: { ...DEFAULT_SONG.constraints },
     melody: { notes: [] },

--- a/src/core/ops.ts
+++ b/src/core/ops.ts
@@ -1,5 +1,5 @@
 import type { DrumId, MelodyNote, NoteName, Song } from "./types";
-import { BLOCKS_MAX, BLOCKS_MIN } from "./defaults";
+import { CELLS_MAX, CELLS_MIN } from "./defaults";
 import { newId } from "./id";
 import {
   clamp,
@@ -206,27 +206,25 @@ export function adjustPitchBound(
   };
 }
 
-export function setBlocks(song: Song, blocks: number): Song {
-  const clamped = clamp(Math.round(blocks), BLOCKS_MIN, BLOCKS_MAX);
-  if (clamped === song.blocks) return song;
-
-  const newTotal = clamped * song.stepsPerBeat;
+export function setCells(song: Song, cells: number): Song {
+  const clamped = clamp(Math.round(cells), CELLS_MIN, CELLS_MAX);
+  if (clamped === song.cells) return song;
 
   // Shrinking: drop notes that start past the new end, and clamp the
   // duration of notes that now overrun it. (No-op when extending.)
   const notes = song.melody.notes
-    .filter((n) => n.startStep < newTotal)
+    .filter((n) => n.startStep < clamped)
     .map((n) => ({
       ...n,
-      durationSteps: Math.min(n.durationSteps, newTotal - n.startStep),
+      durationSteps: Math.min(n.durationSteps, clamped - n.startStep),
     }));
 
   // Shrinking: drop drum hits past the new end.
-  const hits = song.drums.hits.filter((h) => h.step < newTotal);
+  const hits = song.drums.hits.filter((h) => h.step < clamped);
 
   return {
     ...song,
-    blocks: clamped,
+    cells: clamped,
     melody: { ...song.melody, notes },
     drums: { ...song.drums, hits },
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,17 +23,17 @@ export type Constraints = {
   allowAccidentals: boolean;
   allowedNotes: NoteName[] | null;
   tempoLocked: boolean;
-  blocksLocked: boolean;
+  lengthLocked: boolean;
   drumsEnabled: boolean;
 };
 
 export type Song = {
-  version: 2;
+  version: 3;
   bpm: number;
   stepsPerBeat: number;
-  // Grid length in blocks. One block = one beat = `stepsPerBeat` cells,
-  // i.e. one visible group bounded by the beat-start lines.
-  blocks: number;
+  // Grid length as the number of cells (columns) per row, i.e. totalSteps.
+  // stepsPerBeat still groups cells into beats for the rhythm lines/timing.
+  cells: number;
   instrument: InstrumentId;
   constraints: Constraints;
   melody: { notes: MelodyNote[] };

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,7 +5,7 @@ export function clamp(n: number, min: number, max: number): number {
 }
 
 export function totalSteps(song: Song): number {
-  return song.blocks * song.stepsPerBeat;
+  return song.cells;
 }
 
 export function normalizeDuration(

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,7 +8,7 @@ export type Translations = {
   tempo: string;
   sound: string;
   range: string;
-  blocks: string;
+  cells: string;
   allNotes: string;
   nNotes: (n: number) => string;
   blackKeys: string;
@@ -51,7 +51,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "Tempo",
     sound: "Sound",
     range: "Range",
-    blocks: "Blocks",
+    cells: "Cells",
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
     blackKeys: "Black keys",
@@ -87,7 +87,7 @@ export const translations: Record<Locale, Translations> = {
     tempo: "テンポ",
     sound: "おと",
     range: "おんいき",
-    blocks: "ブロック",
+    cells: "マス",
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
     blackKeys: "くろいけんばん",


### PR DESCRIPTION
## What

前回の変更は長さを「ブロック（＝1拍＝`stepsPerBeat`マス）」単位にしたため、1クリックで**4マスがまとめて**増減していました。本来のご要望は **1クリック＝1マス（セル）** です。これを修正しました。

長さを**マス（セル）を直接の単位**にしました（`totalSteps = マス数`、乗数なし）。

## Changes（Song v3）

- `blocks` → `cells`、`totalSteps = cells`
- `constraints.blocksLocked` → `lengthLocked`（単位非依存の名前に。今後の単位変更で再リネーム不要）
- `BLOCKS_MIN/MAX (1..32)` → `CELLS_MIN/MAX (4..128)`、デフォルト 64 マス
- `setBlocks` → `setCells`（±1マス）
- ラベル「ブロック / Blocks」→「マス / Cells」

## 互換移行（保存曲の長さを維持）

`migrateSong()` が過去の全バージョンを変換：
- v1 `bars` → `cells = bars × 4 × stepsPerBeat`
- v2 `blocks` → `cells = blocks × stepsPerBeat`

総マス数は不変なので音は範囲外に出ません。旧 `barsLocked`/`blocksLocked` は `lengthLocked` に集約。

## 検証（実機プレビュー）

- デフォルト 64 マス、ラベル「マス」
- **+1クリック = +1マス（64→65）** ← 今回の修正点
- 最小4（◀無効）/最大128（▶無効）
- **v1保存曲（bars=4）を読み込み → 64マスに移行、メロディ95＋ドラム98ノート・テンポ維持・エラーなし**
- `pnpm build` / `lint` / `tsc` パス

## おわびと経緯

前回「ブロック（拍）＝4マス」と解釈してしまい、ご指摘の「1マスずつ」と食い違っていました。今回マス単位に修正しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)