### PR TITLE
音/ドラムの選択ロック機能（制作者が固定、他の人は周りに追加）

### DIFF
--- a/src/app/components/Grid.tsx
+++ b/src/app/components/Grid.tsx
@@ -42,9 +42,17 @@ export function Grid({
     const isStart = step === note.startStep;
     return (
       <div
-        className={`bubble ${position} ${isStart ? "start-highlight" : ""}`}
+        className={`bubble ${position} ${isStart ? "start-highlight" : ""} ${
+          note.locked ? "locked" : ""
+        }`}
         style={{ backgroundColor: colorForNote(note.note) }}
-      />
+      >
+        {note.locked && isStart && (
+          <span className="lock-badge" aria-hidden="true">
+            🔒
+          </span>
+        )}
+      </div>
     );
   };
 
@@ -66,7 +74,7 @@ export function Grid({
   };
 
   const renderDrumCell = (drumId: DrumId, step: number) => {
-    const hasHit = song.drums.hits.some((h) => h.drumId === drumId && h.step === step);
+    const hit = song.drums.hits.find((h) => h.drumId === drumId && h.step === step);
     const isBeatStart = step % song.stepsPerBeat === 0;
     const isPlayhead = playheadStep === step;
     const handlers = getDrumCellHandlers(drumId, step);
@@ -77,7 +85,18 @@ export function Grid({
         onMouseDown={handlers.onMouseDown}
         onTouchStart={handlers.onTouchStart}
       >
-        {hasHit && <div className="drum-bubble" style={{ backgroundColor: colorForDrum(drumId) }} />}
+        {hit && (
+          <div
+            className={`drum-bubble ${hit.locked ? "locked" : ""}`}
+            style={{ backgroundColor: colorForDrum(drumId) }}
+          >
+            {hit.locked && (
+              <span className="lock-badge" aria-hidden="true">
+                🔒
+              </span>
+            )}
+          </div>
+        )}
       </div>
     );
   };

--- a/src/app/components/SettingsPanel.tsx
+++ b/src/app/components/SettingsPanel.tsx
@@ -19,6 +19,8 @@ interface Props {
   isPlaying: boolean;
   isNotePanelOpen: boolean;
   isConfirmingReset: boolean;
+  isLockMode: boolean;
+  onToggleLockMode: () => void;
   onBpmChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPitchBoundChange: (bound: "min" | "max", direction: "up" | "down") => void;
   onBlocksChange: (direction: "inc" | "dec") => void;
@@ -37,6 +39,8 @@ export function SettingsPanel({
   isPlaying,
   isNotePanelOpen,
   isConfirmingReset,
+  isLockMode,
+  onToggleLockMode,
   onBpmChange,
   onPitchBoundChange,
   onBlocksChange,
@@ -161,6 +165,15 @@ export function SettingsPanel({
               ? t.nNotes(constraints.allowedNotes.length)
               : t.allNotes}
             <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
+          </button>
+        </div>
+        <div className="control-group">
+          <button
+            className={`lock-mode-btn ${isLockMode ? "active" : ""}`}
+            onClick={onToggleLockMode}
+            aria-pressed={isLockMode}
+          >
+            {t.lockMode}
           </button>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,8 @@ import {
   setMelodyNoteDuration,
   toggleAllowedNote,
   toggleDrumHit,
+  toggleMelodyNoteLock,
+  toggleDrumHitLock,
 } from "@/core/ops";
 import { migrateSong } from "@/core/legacy";
 import { buildRangeNotes, findMelodyNoteAt } from "@/ui/grid";
@@ -37,6 +39,7 @@ export default function Home() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  const [isLockMode, setIsLockMode] = useState(false);
 
   const gridRef = useRef<HTMLDivElement>(null);
   const gridContainerRef = useRef<HTMLDivElement>(null);
@@ -124,6 +127,26 @@ export default function Home() {
     pushHistory(songRef.current);
   }, [pushHistory, songRef]);
 
+  const handleToggleMelodyLock = useCallback(
+    (noteName: NoteName, step: number) => {
+      const note = findMelodyNoteAt(song, noteName, step);
+      if (!note) return;
+      pushHistory(song);
+      setSong((prev) => toggleMelodyNoteLock(prev, note.id));
+    },
+    [song, setSong, pushHistory]
+  );
+
+  const handleToggleDrumLock = useCallback(
+    (drumId: DrumId, step: number) => {
+      const hit = song.drums.hits.find((h) => h.drumId === drumId && h.step === step);
+      if (!hit) return;
+      pushHistory(song);
+      setSong((prev) => toggleDrumHitLock(prev, { step, drumId }));
+    },
+    [song, setSong, pushHistory]
+  );
+
   const { isDragging, getMelodyCellHandlers, getDrumCellHandlers, containerHandlers } =
     useDragInteraction({
       gridRef,
@@ -134,6 +157,9 @@ export default function Home() {
       onDragStart: handleDragStart,
       onDrumToggle: handleDrumToggle,
       findNoteAt,
+      isLockMode,
+      onToggleMelodyLock: handleToggleMelodyLock,
+      onToggleDrumLock: handleToggleDrumLock,
     });
 
   const handlePlay = async () => {
@@ -209,7 +235,7 @@ export default function Home() {
 
   return (
     <div
-      className={`app ${isDragging ? "dragging" : ""}`}
+      className={`app ${isDragging ? "dragging" : ""} ${isLockMode ? "lock-mode" : ""}`}
       onMouseMove={containerHandlers.onMouseMove}
       onMouseUp={containerHandlers.onMouseUp}
       onMouseLeave={containerHandlers.onMouseLeave}
@@ -238,6 +264,8 @@ export default function Home() {
           isPlaying={isPlaying}
           isNotePanelOpen={isNotePanelOpen}
           isConfirmingReset={isConfirmingReset}
+          isLockMode={isLockMode}
+          onToggleLockMode={() => setIsLockMode((prev) => !prev)}
           onBpmChange={handleBpmChange}
           onPitchBoundChange={handlePitchBoundChange}
           onBlocksChange={handleBlocksChange}

--- a/src/app/styles/grid.css
+++ b/src/app/styles/grid.css
@@ -230,3 +230,27 @@
 .bubble.preview {
   opacity: 0.5;
 }
+
+/* Locked notes/drums: creator-fixed, read-only. Ringed + a small padlock. */
+.bubble.locked,
+.drum-bubble.locked {
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.85);
+  filter: saturate(0.75);
+}
+
+.lock-badge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 11px;
+  line-height: 1;
+  z-index: 2;
+  pointer-events: none;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+}
+
+/* In lock mode, the whole grid signals "tap to lock/unlock". */
+.lock-mode .cell {
+  cursor: pointer;
+}

--- a/src/app/styles/settings.css
+++ b/src/app/styles/settings.css
@@ -208,6 +208,37 @@
   opacity: 0.9;
 }
 
+/* Lock-mode toggle (taps toggle a note/drum's lock instead of editing) */
+.lock-mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.lock-mode-btn:hover {
+  background: var(--grid-line);
+}
+
+.lock-mode-btn.active {
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+  color: white;
+  border-color: transparent;
+}
+
+.lock-mode-btn.active:hover {
+  opacity: 0.9;
+}
+
 /* Instrument Selector */
 .instrument-selector {
   display: flex;

--- a/src/core/ops.ts
+++ b/src/core/ops.ts
@@ -60,6 +60,14 @@ export function addMelodyNote(
     note,
   };
 
+  // A locked note occupying the same pitch/space wins — can't overwrite it.
+  const samePitchOverlap = song.melody.notes.filter(
+    (existing) => existing.note === note && notesOverlap(existing, newNote)
+  );
+  if (samePitchOverlap.some((n) => n.locked)) {
+    return song;
+  }
+
   const filteredNotes = song.melody.notes.filter((existing) => {
     if (existing.note !== note) return true;
     return !notesOverlap(existing, newNote);
@@ -75,6 +83,8 @@ export function addMelodyNote(
 }
 
 export function removeMelodyNote(song: Song, noteId: string): Song {
+  const target = song.melody.notes.find((n) => n.id === noteId);
+  if (!target || target.locked) return song;
   return {
     ...song,
     melody: {
@@ -89,6 +99,8 @@ export function setMelodyNoteDuration(
   noteId: string,
   durationSteps: number
 ): Song {
+  const target = song.melody.notes.find((n) => n.id === noteId);
+  if (!target || target.locked) return song;
   return {
     ...song,
     melody: {
@@ -98,6 +110,34 @@ export function setMelodyNoteDuration(
         const normalized = normalizeDuration(song, n.startStep, durationSteps);
         return { ...n, durationSteps: normalized };
       }),
+    },
+  };
+}
+
+export function toggleMelodyNoteLock(song: Song, noteId: string): Song {
+  return {
+    ...song,
+    melody: {
+      ...song.melody,
+      notes: song.melody.notes.map((n) =>
+        n.id === noteId ? { ...n, locked: !n.locked } : n
+      ),
+    },
+  };
+}
+
+export function toggleDrumHitLock(
+  song: Song,
+  params: { step: number; drumId: DrumId }
+): Song {
+  const { step, drumId } = params;
+  return {
+    ...song,
+    drums: {
+      ...song.drums,
+      hits: song.drums.hits.map((h) =>
+        h.step === step && h.drumId === drumId ? { ...h, locked: !h.locked } : h
+      ),
     },
   };
 }
@@ -118,6 +158,8 @@ export function toggleDrumHit(
   );
 
   if (existingIndex >= 0) {
+    // Locked hits can't be removed.
+    if (song.drums.hits[existingIndex].locked) return song;
     return {
       ...song,
       drums: {
@@ -207,7 +249,17 @@ export function adjustPitchBound(
 }
 
 export function setBlocks(song: Song, blocks: number): Song {
-  const clamped = clamp(Math.round(blocks), BLOCKS_MIN, BLOCKS_MAX);
+  // Never shrink past a locked element — that would silently delete it.
+  const lockedEnd = Math.max(
+    0,
+    ...song.melody.notes
+      .filter((n) => n.locked)
+      .map((n) => n.startStep + n.durationSteps),
+    ...song.drums.hits.filter((h) => h.locked).map((h) => h.step + 1)
+  );
+  const minBlocks = Math.max(BLOCKS_MIN, Math.ceil(lockedEnd / song.stepsPerBeat));
+
+  const clamped = clamp(Math.round(blocks), minBlocks, BLOCKS_MAX);
   if (clamped === song.blocks) return song;
 
   const newTotal = clamped * song.stepsPerBeat;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -9,12 +9,16 @@ export type MelodyNote = {
   startStep: number;
   durationSteps: number;
   note: NoteName;
+  // Creator-locked: read-only in normal editing (can't remove/move/overwrite).
+  // Optional + absent === unlocked, so old saves need no migration.
+  locked?: boolean;
 };
 
 export type DrumHit = {
   id: string;
   step: number;
   drumId: DrumId;
+  locked?: boolean;
 };
 
 export type Constraints = {

--- a/src/hooks/useDragInteraction.ts
+++ b/src/hooks/useDragInteraction.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import type { RefObject } from "react";
 import type { DrumId, MelodyNote, NoteName } from "@/core/types";
 
@@ -28,6 +28,10 @@ interface UseDragInteractionOptions {
   onDragStart?: () => void;
   onDrumToggle: (drumId: DrumId, step: number) => void;
   findNoteAt: (noteName: NoteName, step: number) => MelodyNote | null;
+  // Lock mode: taps toggle a note/drum's locked flag instead of editing.
+  isLockMode?: boolean;
+  onToggleMelodyLock: (noteName: NoteName, step: number) => void;
+  onToggleDrumLock: (drumId: DrumId, step: number) => void;
 }
 
 export function useDragInteraction({
@@ -39,6 +43,9 @@ export function useDragInteraction({
   onDragStart,
   onDrumToggle,
   findNoteAt,
+  isLockMode = false,
+  onToggleMelodyLock,
+  onToggleDrumLock,
 }: UseDragInteractionOptions) {
   // State for CSS (triggers re-render)
   const [isDragging, setIsDragging] = useState(false);
@@ -50,6 +57,11 @@ export function useDragInteraction({
   const lastTouchXRef = useRef(0);
   // Timestamp to prevent synthetic mouse events after touch
   const lastInteractionEndRef = useRef(0);
+  // Mirror lock mode in a ref so the ref-based handlers read the latest value.
+  const lockModeRef = useRef(isLockMode);
+  useEffect(() => {
+    lockModeRef.current = isLockMode;
+  }, [isLockMode]);
 
   // Start potential interaction (tap or drag - we don't know yet)
   const startInteraction = useCallback(
@@ -71,6 +83,9 @@ export function useDragInteraction({
     (clientX: number) => {
       const pending = pendingRef.current;
       if (!pending || !gridRef.current) return;
+
+      // No drag-to-resize while locking.
+      if (lockModeRef.current) return;
 
       const deltaX = clientX - pending.clientX;
 
@@ -118,8 +133,12 @@ export function useDragInteraction({
     const drag = dragRef.current;
 
     if (pending && !drag) {
-      // No drag occurred - this is a tap
-      if (pending.existingNote) {
+      if (lockModeRef.current) {
+        // Lock mode: tapping an existing note toggles its lock (empty cells do nothing).
+        if (pending.existingNote) {
+          onToggleMelodyLock(pending.noteName, pending.step);
+        }
+      } else if (pending.existingNote) {
         // Tap on existing note - delete it
         onNoteRemove(pending.existingNote.id);
       } else {
@@ -134,7 +153,7 @@ export function useDragInteraction({
     dragRef.current = null;
     setIsDragging(false);
     lastInteractionEndRef.current = Date.now();
-  }, [onNoteCreate, onNoteRemove]);
+  }, [onNoteCreate, onNoteRemove, onToggleMelodyLock]);
 
   // Cancel interaction without finalizing
   const cancelInteraction = useCallback(() => {
@@ -188,20 +207,22 @@ export function useDragInteraction({
         if (Date.now() - lastInteractionEndRef.current < 300) {
           return;
         }
-        onDrumToggle(drumId, step);
+        if (lockModeRef.current) onToggleDrumLock(drumId, step);
+        else onDrumToggle(drumId, step);
       },
       onTouchStart: (e: React.TouchEvent) => {
         e.preventDefault();
         touchCountRef.current = e.touches.length;
         if (e.touches.length === 1) {
-          onDrumToggle(drumId, step);
+          if (lockModeRef.current) onToggleDrumLock(drumId, step);
+          else onDrumToggle(drumId, step);
           lastInteractionEndRef.current = Date.now();
         } else if (e.touches.length >= 2) {
           initMultiTouchScroll(e.touches[0].clientX);
         }
       },
     }),
-    [onDrumToggle, initMultiTouchScroll]
+    [onDrumToggle, onToggleDrumLock, initMultiTouchScroll]
   );
 
   // Container handlers

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -12,6 +12,7 @@ export type Translations = {
   allNotes: string;
   nNotes: (n: number) => string;
   blackKeys: string;
+  lockMode: string;
   settings: string;
   // Actions
   undo: string;
@@ -55,6 +56,7 @@ export const translations: Record<Locale, Translations> = {
     allNotes: "All notes",
     nNotes: (n) => `${n} notes`,
     blackKeys: "Black keys",
+    lockMode: "🔒 Lock",
     settings: "Settings",
     undo: "Undo",
     reset: "Reset",
@@ -91,6 +93,7 @@ export const translations: Record<Locale, Translations> = {
     allNotes: "ぜんぶのおと",
     nNotes: (n) => `${n}このおと`,
     blackKeys: "くろいけんばん",
+    lockMode: "🔒 ロック",
     settings: "せってい",
     undo: "もどす",
     reset: "リセット",


### PR DESCRIPTION
Closes #26

## What

制作者が特定の音・ドラムを「ロック」して固定でき、その曲を開いた他の人は**ロック要素を編集できず、周りに自由に追加できる**ようにしました。固定の伴奏（ベース）を残して子どもがメロディを乗せる、足場かけの用途です。

## How

- **モデル**: `MelodyNote` / `DrumHit` に `locked?: boolean` を追加。**任意・追加のみ**なので旧データの移行不要（省略＝未ロック、`migrateSong` はそのまま通す）
- **コア (`ops.ts`)**: ロック要素は読み取り専用 —
  - `removeMelodyNote` / `setMelodyNoteDuration` / `toggleDrumHit`: ロック要素には no-op
  - `addMelodyNote`: ロック音には上書き不可（last-write-wins の対象外）
  - `setBlocks`: ロック要素より短くは縮められない（誤消し防止）
  - 新 op: `toggleMelodyNoteLock` / `toggleDrumHitLock`
- **エディタ**: 設定パネルに「🔒 ロック / Lock」モード。ON中はセル/ドラムのタップで**ロックON/OFFを切替**（通常編集と分離）。ロックモード中はドラッグ長さ変更を無効化
- **表示**: ロック要素は 🔒 バッジ＋白リング＋低彩度で区別
- **設計**: 認証が無い前提のソフトロック（教室用ガードレール）。将来のアカウント/権限層と競合せず、その上に乗る形

## Verification（実機プレビュー）

- ロックモードでメロディ音・ドラムを個別にロック → 🔒 表示
- 通常モードでロック要素は削除不可、ロック音は上書き不可
- ロック要素の周りには通常どおり追加可
- コンソールエラーなし、`pnpm lint` / `tsc` / `build` パス

## スコープ外（将来）

- 認証によるロックの強制（ハードロック）、作者本人だけがロックを編集できる権限制御

🤖 Generated with [Claude Code](https://claude.com/claude-code)