### PR TITLE
fix: 再生中に画面遷移すると音が止まらないバグを修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,6 +45,12 @@ export default function Home() {
   const gridContainerRef = useRef<HTMLDivElement>(null);
   const engineRef = useRef<AudioEngine | null>(null);
 
+  // Tear down audio when the editor unmounts (e.g. tapping "みんなの曲" mid-play),
+  // otherwise the scheduler keeps running and the song can't be stopped.
+  useEffect(() => {
+    return () => engineRef.current?.dispose();
+  }, []);
+
   // ?load=<id> で曲を読み込む
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -371,6 +371,18 @@ export class AudioEngine {
     this.currentStep = 0;
   }
 
+  // Stop the scheduler and tear down the AudioContext. Call when the editor
+  // unmounts (e.g. navigating away mid-playback) so audio can't keep running.
+  dispose(): void {
+    this.stop();
+    if (this.ctx) {
+      this.ctx.close().catch(() => {});
+      this.ctx = null;
+      this.masterGain = null;
+      this.noiseBuffer = null;
+    }
+  }
+
   getState(): TransportState {
     return this.state;
   }


### PR DESCRIPTION
## 症状

曲を入力 → 「えんそう」で再生 → 流したまま「みんなの曲」を押すと、画面遷移後も**音が鳴り続け、停止できなくなる**。

## 原因

再生は `AudioEngine` の `setInterval`（先読みスケジューラ）で鳴り続ける。「みんなの曲」は `<Link>` のクライアント遷移でエディタ（`page.tsx`）がアンマウントされるが、**アンマウント時にエンジンを止めていなかった**ため、画面が消えてもスケジューラだけが生き続けていた。

## 修正

- `src/audio/engine.ts`: `dispose()` を追加（`stop()` でスケジューラ停止 ＋ `AudioContext.close()` で音そのものを即停止・解放）
- `src/app/page.tsx`: アンマウント時のクリーンアップで `engineRef.current?.dispose()` を呼ぶ

エディタに戻ると `getEngine()` が新しいエンジン＋新しい AudioContext を作るため、再生は問題なく継続利用できる。

ユーザーから見た挙動は「とめる」を押したのと同じ（音が即止まる）。内部的には不要になった音声リソースも破棄する点だけ「とめる」より強い。

## 検証（実機プレビュー）

- 再生 → /songs へ遷移 → AudioContext が `running` → **`closed`**（音が止まる）
- エディタに戻って再生 → 新しいコンテキストが `running`（旧は `closed` のまま）= 再生継続可・リークなし
- コンソールエラーなし、`pnpm lint` / `tsc` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)