### PR TITLE
fix: クリック可能なボタン/領域にポインターカーソルを表示

### DIFF
--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -44,6 +44,14 @@ a {
   text-decoration: none;
 }
 
+/* Clickable controls always show the pointer cursor (UX polish).
+   Disabled buttons are excluded so their not-allowed cursor still wins. */
+button:not(:disabled),
+a[href],
+[role="button"] {
+  cursor: pointer;
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;

--- a/src/app/styles/modal.css
+++ b/src/app/styles/modal.css
@@ -7,6 +7,8 @@
   align-items: center;
   justify-content: center;
   z-index: 100;
+  /* Clicking the backdrop closes the modal. */
+  cursor: pointer;
 }
 
 .modal {
@@ -18,6 +20,8 @@
   flex-direction: column;
   gap: 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  /* The dialog itself isn't click-to-close — reset the inherited pointer. */
+  cursor: default;
 }
 
 .modal-title {


### PR DESCRIPTION
## What

クリックできるコントロールでマウスカーソルが矢印のまま（ポインターにならない）箇所があったのを修正し、UX を統一しました。

ネイティブの `<button>` はブラウザ既定で矢印カーソルのため、明示指定が無いと「押せなさそう」に見えていました。

## Changes

- `styles/base.css`: グローバルルールを追加
  ```css
  button:not(:disabled),
  a[href],
  [role="button"] { cursor: pointer; }
  ```
  無効化されたボタンは `:not(:disabled)` で除外しているため、`not-allowed` カーソルがそのまま優先されます。
- `styles/modal.css`: モーダルの背景（クリックで閉じる領域）に `cursor: pointer`、ダイアログ本体は `cursor: default` にリセット。

## Verification（実機プレビューで computed style 確認）

- 有効なボタン/リンク = `pointer`
- 無効なボタン（停止・もどす・保存[未入力時]）= `not-allowed`（回帰なし）
- モーダル背景 = `pointer`、ダイアログ = `default`、テキスト入力 = `text`
- `pnpm lint` / `build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)