### PR TITLE
feat: 公開フィードの入力安全対策（クライアント層） (#31)

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -5,6 +5,12 @@ import type { Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
+import {
+  MAX_TITLE_LENGTH,
+  MAX_AUTHOR_LENGTH,
+  validateSongMeta,
+  songWithinSizeLimit,
+} from "@/lib/validation";
 
 interface Props {
   song: Song;
@@ -17,17 +23,36 @@ export function SaveModal({ song, locale, onClose }: Props) {
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSave = async () => {
-    if (!title.trim() || !author.trim()) return;
+    const meta = validateSongMeta({ title, author });
+    if (!meta.ok) {
+      // Empty/length issues are already gated by the disabled button + maxLength;
+      // the meaningful client-side rejection here is the blocked word.
+      if (meta.reason === "blocked-word") setError(t.saveErrorBlockedWord);
+      return;
+    }
+    if (!songWithinSizeLimit(song)) {
+      setError(t.saveErrorTooLarge);
+      return;
+    }
+
     setSaving(true);
+    setError(null);
     try {
-      await supabase.from("songs").insert({
+      const { error: dbError } = await supabase.from("songs").insert({
         title: title.trim(),
         author: author.trim(),
         song_data: song,
       });
+      if (dbError) {
+        setError(t.saveErrorFailed);
+        return;
+      }
       onClose();
+    } catch {
+      setError(t.saveErrorFailed);
     } finally {
       setSaving(false);
     }
@@ -42,18 +67,25 @@ export function SaveModal({ song, locale, onClose }: Props) {
             className="modal-input"
             placeholder={t.titlePlaceholder}
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            maxLength={60}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              if (error) setError(null);
+            }}
+            maxLength={MAX_TITLE_LENGTH}
             autoFocus
           />
           <input
             className="modal-input"
             placeholder={t.authorPlaceholder}
             value={author}
-            onChange={(e) => setAuthor(e.target.value)}
-            maxLength={40}
+            onChange={(e) => {
+              setAuthor(e.target.value);
+              if (error) setError(null);
+            }}
+            maxLength={MAX_AUTHOR_LENGTH}
           />
         </div>
+        {error && <p className="modal-error">{error}</p>}
         <div className="modal-actions">
           <button className="modal-cancel" onClick={onClose}>
             {t.cancel}

--- a/src/app/styles/modal.css
+++ b/src/app/styles/modal.css
@@ -74,6 +74,13 @@
   opacity: 1;
 }
 
+.modal-error {
+  margin: -4px 0 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #ee5253;
+}
+
 .modal-save {
   padding: 8px 20px;
   border-radius: 12px;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -31,6 +31,9 @@ export type Translations = {
   authorPlaceholder: string;
   cancel: string;
   saving: string;
+  saveErrorBlockedWord: string;
+  saveErrorTooLarge: string;
+  saveErrorFailed: string;
   // Songs page
   backToCreate: string;
   pageTitle: string;
@@ -72,6 +75,9 @@ export const translations: Record<Locale, Translations> = {
     authorPlaceholder: "Your name",
     cancel: "Cancel",
     saving: "Saving...",
+    saveErrorBlockedWord: "That title or name can't be used.",
+    saveErrorTooLarge: "This song is too large to save.",
+    saveErrorFailed: "Couldn't save. Please try again.",
     backToCreate: "← Create",
     pageTitle: "Everyone's Songs",
     loading: "Loading...",
@@ -109,6 +115,9 @@ export const translations: Record<Locale, Translations> = {
     authorPlaceholder: "あなたのなまえ",
     cancel: "キャンセル",
     saving: "ほぞんちゅう...",
+    saveErrorBlockedWord: "つかえない ことばが はいっています。",
+    saveErrorTooLarge: "きょくが おおきすぎて ほぞんできません。",
+    saveErrorFailed: "ほぞんに しっぱいしました。もういちど ためしてね。",
     backToCreate: "← つくる",
     pageTitle: "みんなの曲",
     loading: "よみこみちゅう...",

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSongMeta,
+  containsBlockedWord,
+  songWithinSizeLimit,
+  MAX_TITLE_LENGTH,
+  MAX_AUTHOR_LENGTH,
+} from "./validation";
+
+describe("validateSongMeta", () => {
+  it("accepts normal title/author", () => {
+    expect(validateSongMeta({ title: "茶つみ", author: "たろう" })).toEqual({ ok: true });
+  });
+
+  it("trims and rejects empty", () => {
+    expect(validateSongMeta({ title: "   ", author: "a" })).toEqual({
+      ok: false,
+      reason: "title-empty",
+    });
+    expect(validateSongMeta({ title: "ok", author: "  " })).toEqual({
+      ok: false,
+      reason: "author-empty",
+    });
+  });
+
+  it("rejects over-length input", () => {
+    expect(validateSongMeta({ title: "x".repeat(MAX_TITLE_LENGTH + 1), author: "a" })).toEqual({
+      ok: false,
+      reason: "title-too-long",
+    });
+    expect(validateSongMeta({ title: "ok", author: "y".repeat(MAX_AUTHOR_LENGTH + 1) })).toEqual({
+      ok: false,
+      reason: "author-too-long",
+    });
+  });
+
+  it("rejects blocked words (case-insensitive, in title or author)", () => {
+    expect(validateSongMeta({ title: "FUCK you", author: "a" })).toEqual({
+      ok: false,
+      reason: "blocked-word",
+    });
+    expect(validateSongMeta({ title: "song", author: "しね" })).toEqual({
+      ok: false,
+      reason: "blocked-word",
+    });
+  });
+});
+
+describe("containsBlockedWord", () => {
+  it("detects substrings case-insensitively", () => {
+    expect(containsBlockedWord("ShItpost")).toBe(true);
+    expect(containsBlockedWord("happy song")).toBe(false);
+  });
+});
+
+describe("songWithinSizeLimit", () => {
+  it("accepts small payloads and rejects huge ones", () => {
+    expect(songWithinSizeLimit({ a: 1 })).toBe(true);
+    expect(songWithinSizeLimit({ big: "x".repeat(200_000) })).toBe(false);
+  });
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,59 @@
+// Client-side validation for the public song feed.
+//
+// NOTE: this is a UX guardrail, not security. The anon key lets anyone POST
+// directly to Supabase, so the real enforcement must live server-side
+// (RLS / Postgres CHECK / trigger / a moderation service). See issue #31.
+
+export const MAX_TITLE_LENGTH = 60;
+export const MAX_AUTHOR_LENGTH = 40;
+// Generous ceiling on the serialized song to stop abusive payloads.
+export const MAX_SONG_BYTES = 100_000;
+
+// Starter blocklist — intentionally small. Expand or, better, replace with a
+// server-side moderation service. Matching is case-insensitive substring.
+const BLOCKED_WORDS = [
+  "fuck",
+  "shit",
+  "bitch",
+  "asshole",
+  "slut",
+  "しね",
+  "ころす",
+  "きもい",
+];
+
+export type MetaValidationReason =
+  | "title-empty"
+  | "title-too-long"
+  | "author-empty"
+  | "author-too-long"
+  | "blocked-word";
+
+export type MetaValidation = { ok: true } | { ok: false; reason: MetaValidationReason };
+
+export function containsBlockedWord(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  return BLOCKED_WORDS.some((word) => normalized.includes(word));
+}
+
+export function validateSongMeta(input: { title: string; author: string }): MetaValidation {
+  const title = input.title.trim();
+  const author = input.author.trim();
+
+  if (title.length === 0) return { ok: false, reason: "title-empty" };
+  if (title.length > MAX_TITLE_LENGTH) return { ok: false, reason: "title-too-long" };
+  if (author.length === 0) return { ok: false, reason: "author-empty" };
+  if (author.length > MAX_AUTHOR_LENGTH) return { ok: false, reason: "author-too-long" };
+  if (containsBlockedWord(title) || containsBlockedWord(author)) {
+    return { ok: false, reason: "blocked-word" };
+  }
+  return { ok: true };
+}
+
+export function songWithinSizeLimit(song: unknown): boolean {
+  try {
+    return JSON.stringify(song).length <= MAX_SONG_BYTES;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Refs #31

## What

#31 の第1層（クライアント側）。保存時の入力検証・NGワード・サイズ上限・失敗時メッセージを追加。

> ⚠️ これは **UXガードレールであってセキュリティではありません**。匿名キーで直接 POST できるため、本当の防御はサーバー側（RLS / CHECK / トリガー / レート制限 / モデレーション）が必要。これは #31 の第2層として別途対応。

## Changes

- **`lib/validation.ts`**（純粋・テスト済）: タイトル/作者名の長さ・空チェック、小さなNGワード初期リスト（要拡張、サーバー側へ移行が本筋）、曲データのサイズ上限（100KB）
- **SaveModal**: 保存前に検証し、ローカライズされたエラーを表示。挿入失敗も無言で終わらせずメッセージ表示。編集でエラー解除
- **i18n**: blocked-word / too-large / save-failed（ja/en）
- ユニットテスト6件追加

## Verification

- 実機: NGワード（例 `shit` / `しね`）入力で**エラー表示・保存ブロック**を確認
- `pnpm test` 47件パス、lint/tsc/build グリーン

## 次（#31 第2層・別PR）

- RLS 見直し（無制限insertの是正）、サーバー側の長さ/サイズCHECK、レート制限、不適切曲の非表示(`hidden`列)＋通報

🤖 Generated with [Claude Code](https://claude.com/claude-code)