### PR TITLE
chore: 公開フィードのサーバー側安全対策（適用済みマイグレーションを記録）(#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,24 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
 
 ```bash
 pnpm install
-pnpm dev        # http://localhost:3000
-pnpm lint       # ESLint
-pnpm format     # Prettier
+pnpm dev          # http://localhost:3000
+pnpm lint         # ESLint
+pnpm test         # Vitest（コアのユニットテスト）
+pnpm format       # Prettier
 ```
+
+## 公開フィードの安全対策・モデレーション
+
+`/songs` は匿名で読み書きできる公開フィード。安全対策は2層:
+
+- **クライアント層（UX）**: `src/lib/validation.ts` — タイトル/作者名の長さ・空チェック、NGワード、曲データのサイズ上限。保存前に検証してエラー表示。
+- **サーバー層（強制）**: `supabase/migrations/0001_harden_songs_feed_safety.sql` — CHECK 制約（長さ/サイズ）、`hidden` モデレーション列、RLS で公開は「表示中の行」のみ読み書き可。匿名は更新/削除不可。
+
+不適切な曲を隠す（サービスロール / SQL エディタ）:
+
+```sql
+update public.songs set hidden = true  where id = '<uuid>';  -- 非表示
+update public.songs set hidden = false where id = '<uuid>';  -- 復帰
+```
+
+未対応（#31）: レート制限（エッジ関数が適切。素朴なDBトリガーは授業中の同時保存を阻害するため不可）、通報フロー（`reports` テーブル＋通報ボタン）。

--- a/supabase/migrations/0001_harden_songs_feed_safety.sql
+++ b/supabase/migrations/0001_harden_songs_feed_safety.sql
@@ -1,0 +1,43 @@
+-- #31 — server-side safety for the public `songs` feed.
+-- Applied to the BeatBubble Supabase project via the management API.
+-- Kept here for version control / reproducibility.
+--
+-- Summary:
+--   * `hidden` moderation flag — hidden rows disappear from the public feed/load.
+--   * CHECK constraints enforce title/author length + non-empty and a song_data
+--     size ceiling SERVER-SIDE (the client limits in src/lib/validation.ts are a
+--     looser UX layer that can be bypassed via the anon key).
+--   * RLS tightened so the public can only read/insert VISIBLE rows. There are no
+--     UPDATE/DELETE policies, so anon cannot modify or delete; moderation is done
+--     with the service role (dashboard / SQL).
+
+alter table public.songs
+  add column if not exists hidden boolean not null default false;
+
+alter table public.songs
+  add constraint songs_title_len
+    check (char_length(title) between 1 and 100 and btrim(title) <> ''),
+  add constraint songs_author_len
+    check (char_length(author) between 1 and 60 and btrim(author) <> ''),
+  add constraint songs_song_data_size
+    check (length(song_data::text) <= 200000);
+
+drop policy if exists "public read" on public.songs;
+drop policy if exists "public insert" on public.songs;
+
+create policy "public read visible" on public.songs
+  for select to public using (hidden = false);
+
+create policy "public insert visible" on public.songs
+  for insert to public with check (hidden = false);
+
+-- Moderation runbook (service role / SQL editor):
+--   hide a song:    update public.songs set hidden = true  where id = '<uuid>';
+--   restore a song: update public.songs set hidden = false where id = '<uuid>';
+--
+-- Deferred (tracked in #31):
+--   * Rate limiting — belongs at the edge (Edge Function / gateway), NOT a naive
+--     Postgres window trigger, which would block legitimate classroom bursts
+--     (a whole class saving at once).
+--   * Report inflow — a `reports` table + a client "report" button so reports
+--     drive the `hidden` flag.


### PR DESCRIPTION
Refs #31

## What

#31 の第2層（サーバー側の本防御）を **Supabase に適用済み**。本PRはその SQL を版管理に残し、モデレーション手順を文書化するもの（アプリのコード変更なし）。

## 適用済みのDB変更（本番）

`supabase/migrations/0001_harden_songs_feed_safety.sql`:
- **`hidden`** モデレーション列（既定 false）。非表示行は公開フィード/読み込みから消える
- **CHECK 制約**（サーバー側で強制 = 匿名キー直叩きでも回避不可）:
  - タイトル 1..100 かつ空白のみ不可
  - 作者名 1..60 かつ空白のみ不可
  - `song_data` テキスト長 ≤ 200,000
- **RLS 厳格化**: 公開は「表示中(hidden=false)の行」のみ read/insert。UPDATE/DELETE ポリシー無し＝匿名は更新/削除不可。モデレーションはサービスロールで実施

## 検証（本番DBで確認）

- 既存9曲すべて visible（挙動不変）
- 空タイトル / 30万文字の song_data の insert は **CHECK で拒否**（テスト行は残らず、9件のまま）
- `get_advisors(security)` = lint なし

## モデレーション
```sql
update public.songs set hidden = true  where id = '<uuid>';  -- 非表示
update public.songs set hidden = false where id = '<uuid>';  -- 復帰
```

## 未対応（#31 に残す）
- レート制限（エッジ関数が適切。素朴なDBトリガーは授業中の同時保存を阻害するため不可）
- 通報フロー（`reports` テーブル＋通報ボタン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)