### PR TITLE
feat: Googleログイン（任意）＋曲の所有権 (#34)

### DIFF
--- a/src/app/components/AuthButton.tsx
+++ b/src/app/components/AuthButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { User } from "@supabase/supabase-js";
+import type { Translations } from "@/lib/i18n";
+import { authDisplayName } from "@/hooks/useAuth";
+
+interface Props {
+  user: User | null;
+  t: Translations;
+  onSignIn: () => void;
+  onSignOut: () => void;
+}
+
+// Shared login/logout control for the editor and songs headers.
+export function AuthButton({ user, t, onSignIn, onSignOut }: Props) {
+  const name = authDisplayName(user);
+  return name ? (
+    <button className="auth-btn" onClick={onSignOut} title={name}>
+      {t.logout}
+    </button>
+  ) : (
+    <button className="auth-btn" onClick={onSignIn}>
+      {t.login}
+    </button>
+  );
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import type { User } from "@supabase/supabase-js";
 import type { Translations } from "@/lib/i18n";
+import { AuthButton } from "./AuthButton";
 
 interface Props {
   t: Translations;
@@ -14,7 +16,7 @@ interface Props {
   onToggleSettings: () => void;
   onOpenSave: () => void;
   onToggleLocale: () => void;
-  userName: string | null;
+  user: User | null;
   onSignIn: () => void;
   onSignOut: () => void;
 }
@@ -30,7 +32,7 @@ export function Header({
   onToggleSettings,
   onOpenSave,
   onToggleLocale,
-  userName,
+  user,
   onSignIn,
   onSignOut,
 }: Props) {
@@ -76,15 +78,7 @@ export function Header({
       <button className="locale-toggle" onClick={onToggleLocale}>
         {t.switchLocale}
       </button>
-      {userName ? (
-        <button className="auth-btn" onClick={onSignOut} title={userName}>
-          {t.logout}
-        </button>
-      ) : (
-        <button className="auth-btn" onClick={onSignIn}>
-          {t.login}
-        </button>
-      )}
+      <AuthButton user={user} t={t} onSignIn={onSignIn} onSignOut={onSignOut} />
     </header>
   );
 }

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -14,6 +14,9 @@ interface Props {
   onToggleSettings: () => void;
   onOpenSave: () => void;
   onToggleLocale: () => void;
+  userName: string | null;
+  onSignIn: () => void;
+  onSignOut: () => void;
 }
 
 export function Header({
@@ -27,6 +30,9 @@ export function Header({
   onToggleSettings,
   onOpenSave,
   onToggleLocale,
+  userName,
+  onSignIn,
+  onSignOut,
 }: Props) {
   return (
     <header className="header">
@@ -70,6 +76,15 @@ export function Header({
       <button className="locale-toggle" onClick={onToggleLocale}>
         {t.switchLocale}
       </button>
+      {userName ? (
+        <button className="auth-btn" onClick={onSignOut} title={userName}>
+          {t.logout}
+        </button>
+      ) : (
+        <button className="auth-btn" onClick={onSignIn}>
+          {t.login}
+        </button>
+      )}
     </header>
   );
 }

--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -15,13 +15,15 @@ import {
 interface Props {
   song: Song;
   locale: Locale;
+  userId: string | null;
+  defaultAuthor?: string;
   onClose: () => void;
 }
 
-export function SaveModal({ song, locale, onClose }: Props) {
+export function SaveModal({ song, locale, userId, defaultAuthor = "", onClose }: Props) {
   const t = translations[locale];
   const [title, setTitle] = useState("");
-  const [author, setAuthor] = useState("");
+  const [author, setAuthor] = useState(defaultAuthor);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,6 +47,7 @@ export function SaveModal({ song, locale, onClose }: Props) {
         title: title.trim(),
         author: author.trim(),
         song_data: song,
+        user_id: userId,
       });
       if (dbError) {
         setError(t.saveErrorFailed);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -262,7 +262,7 @@ export default function Home() {
         onToggleSettings={handleToggleSettings}
         onOpenSave={() => setIsSaveModalOpen(true)}
         onToggleLocale={toggleLocale}
-        userName={authDisplayName(user) || null}
+        user={user}
         onSignIn={signInWithGoogle}
         onSignOut={signOut}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ import { AudioEngine } from "@/audio/engine";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
 import { useLocale } from "@/hooks/useLocale";
 import { useSong } from "@/hooks/useSong";
+import { useAuth, authDisplayName } from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { SaveModal } from "./components/SaveModal";
 import { NotePanel } from "./components/NotePanel";
@@ -31,6 +32,7 @@ import { Grid } from "./components/Grid";
 
 export default function Home() {
   const { locale, t, toggleLocale } = useLocale();
+  const { user, signInWithGoogle, signOut } = useAuth();
   const { song, setSong, songRef, canUndo, pushHistory, undo, reset } = useSong();
 
   const [isPlaying, setIsPlaying] = useState(false);
@@ -260,6 +262,9 @@ export default function Home() {
         onToggleSettings={handleToggleSettings}
         onOpenSave={() => setIsSaveModalOpen(true)}
         onToggleLocale={toggleLocale}
+        userName={authDisplayName(user) || null}
+        onSignIn={signInWithGoogle}
+        onSignOut={signOut}
       />
 
       {isSettingsOpen && (
@@ -305,7 +310,13 @@ export default function Home() {
       />
 
       {isSaveModalOpen && (
-        <SaveModal song={song} locale={locale} onClose={() => setIsSaveModalOpen(false)} />
+        <SaveModal
+          song={song}
+          locale={locale}
+          userId={user?.id ?? null}
+          defaultAuthor={authDisplayName(user)}
+          onClose={() => setIsSaveModalOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
-import { useAuth, authDisplayName } from "@/hooks/useAuth";
+import { useAuth } from "@/hooks/useAuth";
+import { AuthButton } from "@/app/components/AuthButton";
 import type { Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
@@ -65,15 +66,7 @@ export default function SongsPage() {
         <button className="locale-toggle" onClick={toggleLocale}>
           {t.switchLocale}
         </button>
-        {authDisplayName(user) ? (
-          <button className="auth-btn" onClick={signOut} title={authDisplayName(user)}>
-            {t.logout}
-          </button>
-        ) : (
-          <button className="auth-btn" onClick={signInWithGoogle}>
-            {t.login}
-          </button>
-        )}
+        <AuthButton user={user} t={t} onSignIn={signInWithGoogle} onSignOut={signOut} />
       </header>
 
       <main className="songs-main">

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
+import { useAuth, authDisplayName } from "@/hooks/useAuth";
 import type { Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
@@ -38,6 +39,7 @@ function timeAgo(dateStr: string, locale: Locale): string {
 
 export default function SongsPage() {
   const { locale, t, toggleLocale } = useLocale();
+  const { user, signInWithGoogle, signOut } = useAuth();
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -63,6 +65,15 @@ export default function SongsPage() {
         <button className="locale-toggle" onClick={toggleLocale}>
           {t.switchLocale}
         </button>
+        {authDisplayName(user) ? (
+          <button className="auth-btn" onClick={signOut} title={authDisplayName(user)}>
+            {t.logout}
+          </button>
+        ) : (
+          <button className="auth-btn" onClick={signInWithGoogle}>
+            {t.login}
+          </button>
+        )}
       </header>
 
       <main className="songs-main">

--- a/src/app/styles/header.css
+++ b/src/app/styles/header.css
@@ -266,3 +266,27 @@
   border-color: transparent;
   color: white;
 }
+
+/* Auth (Google sign-in / sign-out) — shared by editor + songs headers */
+.auth-btn {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1.5px solid var(--grid-line);
+  background: transparent;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.auth-btn:hover {
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+  border-color: transparent;
+  color: white;
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+
+// Optional Google sign-in. Anonymous use keeps working; signing in lets a
+// user own (and later manage) the songs they save.
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null);
+      setReady(true);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  const signInWithGoogle = () =>
+    supabase.auth.signInWithOAuth({
+      provider: "google",
+      // Works for both localhost and the deployed origin.
+      options: { redirectTo: window.location.origin },
+    });
+
+  const signOut = () => supabase.auth.signOut();
+
+  return { user, ready, signInWithGoogle, signOut };
+}
+
+// Friendly display name from Google metadata, falling back to email.
+export function authDisplayName(user: User | null): string {
+  if (!user) return "";
+  const meta = user.user_metadata as { full_name?: string; name?: string };
+  return meta.full_name || meta.name || user.email || "";
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -46,6 +46,8 @@ export type Translations = {
   daysAgo: (n: number) => string;
   // Locale toggle label (the language you'll switch TO)
   switchLocale: string;
+  login: string;
+  logout: string;
 };
 
 export const translations: Record<Locale, Translations> = {
@@ -88,6 +90,8 @@ export const translations: Record<Locale, Translations> = {
     hoursAgo: (n) => `${n}h ago`,
     daysAgo: (n) => `${n}d ago`,
     switchLocale: "日本語",
+    login: "Log in",
+    logout: "Log out",
   },
   ja: {
     play: "えんそう",
@@ -128,5 +132,7 @@ export const translations: Record<Locale, Translations> = {
     hoursAgo: (n) => `${n}時間まえ`,
     daysAgo: (n) => `${n}日まえ`,
     switchLocale: "EN",
+    login: "ログイン",
+    logout: "ログアウト",
   },
 };

--- a/supabase/migrations/0002_songs_ownership.sql
+++ b/supabase/migrations/0002_songs_ownership.sql
@@ -1,0 +1,28 @@
+-- #34 — song ownership for optional Google sign-in.
+-- Applied to the BeatBubble Supabase project via the management API.
+--
+-- Additive & backward compatible: anonymous saves (user_id null) keep working
+-- exactly as before; signing in lets a user own the songs they save.
+
+alter table public.songs
+  add column if not exists user_id uuid references auth.users(id) on delete set null;
+
+create index if not exists songs_user_id_idx on public.songs(user_id);
+
+-- Insert: anon may post (user_id null); a signed-in user may only post as self.
+drop policy if exists "public insert visible" on public.songs;
+create policy "insert own or anon" on public.songs
+  for insert to public
+  with check (hidden = false and (user_id is null or user_id = auth.uid()));
+
+-- Owners may edit / delete only their own VISIBLE rows
+-- (moderated/hidden rows stay locked; the `using (hidden=false)` clause also
+--  prevents an owner from un-hiding a moderated song).
+create policy "owner update" on public.songs
+  for update to public
+  using (auth.uid() = user_id and hidden = false)
+  with check (auth.uid() = user_id and hidden = false);
+
+create policy "owner delete" on public.songs
+  for delete to public
+  using (auth.uid() = user_id and hidden = false);


### PR DESCRIPTION
Refs #34

## What

匿名利用はそのまま、**Googleログイン（任意）**でログインすると保存した曲を自分のものとして所有できるように。`/songs` の「自分の曲」管理（#35）の土台。

## DB（Supabase に適用済み・SQLは `supabase/migrations/0002_songs_ownership.sql` で版管理）

- `songs.user_id` → `auth.users`（nullable, on delete set null）＋ index
- RLS: insert は匿名(user_id null) か本人のみ。update/delete は**所有者の表示中の行のみ**（モデレーションで非表示の行は所有者も触れない）

## クライアント

- `useAuth`（getSession + onAuthStateChange、signInWithGoogle / signOut）、`authDisplayName`。リダイレクトは `window.location.origin`（localhost/本番自動対応）
- エディタ／songs 両ヘッダーに ログイン/ログアウト ボタン
- SaveModal が `user_id` を付与し、作者名を Google 名で初期入力
- i18n: login / logout（ja/en）

## 検証（匿名・プロバイダ未設定の状態）

- 両ヘッダーに「ログイン」表示、フィードは従来どおり読み込み、保存フロー不変、コンソールエラーなし
- `pnpm lint` / `tsc` / `build` グリーン、47テストパス

## ⚠️ オーナー作業（これが済むまで実ログインはテスト不可）

Google Cloud と Supabase でのOAuth設定が必要です：
1. **Google Cloud**: OAuth クライアント(ウェブ)を作成。承認済みリダイレクトURI = `https://pfdrdecuouvmkqyaajcf.supabase.co/auth/v1/callback`、JS生成元に `http://localhost:3000` と本番ドメイン
2. **Supabase**: Authentication → Providers → Google を有効化し ClientID/Secret を設定。URL Configuration の Redirect URLs に `http://localhost:3000/**` と本番 `https://<your-app>/**`

設定後にログイン動作を一緒に確認 → #34 クローズ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)