### PR TITLE
feat: 「自分の曲」管理（フィルタ・改名・削除・上書き保存）(#35)

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -19,6 +19,9 @@ interface Props {
   defaultAuthor?: string;
   // When set, the loaded song is owned by the current user and can be overwritten.
   existing?: { id: string; title: string; author: string } | null;
+  // Called after a successful overwrite so the caller can keep its loaded-song
+  // title/author in sync (avoids a stale prefill reverting the name next time).
+  onOverwritten?: (title: string, author: string) => void;
   onClose: () => void;
 }
 
@@ -28,6 +31,7 @@ export function SaveModal({
   userId,
   defaultAuthor = "",
   existing = null,
+  onOverwritten,
   onClose,
 }: Props) {
   const t = translations[locale];
@@ -51,7 +55,7 @@ export function SaveModal({
     return true;
   };
 
-  const run = async (op: () => Promise<{ error: unknown }>) => {
+  const run = async (op: () => Promise<{ error: unknown }>, onSuccess?: () => void) => {
     if (!guard()) return;
     setSaving(true);
     setError(null);
@@ -61,6 +65,7 @@ export function SaveModal({
         setError(t.saveErrorFailed);
         return;
       }
+      onSuccess?.();
       onClose();
     } catch {
       setError(t.saveErrorFailed);
@@ -80,11 +85,13 @@ export function SaveModal({
     );
 
   const handleOverwrite = () =>
-    run(async () =>
-      supabase
-        .from("songs")
-        .update({ title: title.trim(), author: author.trim(), song_data: song })
-        .eq("id", existing!.id)
+    run(
+      async () =>
+        supabase
+          .from("songs")
+          .update({ title: title.trim(), author: author.trim(), song_data: song })
+          .eq("id", existing!.id),
+      () => onOverwritten?.(title.trim(), author.trim())
     );
 
   const canSave = !saving && !!title.trim() && !!author.trim();

--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -17,38 +17,46 @@ interface Props {
   locale: Locale;
   userId: string | null;
   defaultAuthor?: string;
+  // When set, the loaded song is owned by the current user and can be overwritten.
+  existing?: { id: string; title: string; author: string } | null;
   onClose: () => void;
 }
 
-export function SaveModal({ song, locale, userId, defaultAuthor = "", onClose }: Props) {
+export function SaveModal({
+  song,
+  locale,
+  userId,
+  defaultAuthor = "",
+  existing = null,
+  onClose,
+}: Props) {
   const t = translations[locale];
-  const [title, setTitle] = useState("");
-  const [author, setAuthor] = useState(defaultAuthor);
+  const [title, setTitle] = useState(existing ? existing.title : "");
+  const [author, setAuthor] = useState(existing ? existing.author : defaultAuthor);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSave = async () => {
+  const guard = (): boolean => {
     const meta = validateSongMeta({ title, author });
     if (!meta.ok) {
-      // Empty/length issues are already gated by the disabled button + maxLength;
-      // the meaningful client-side rejection here is the blocked word.
+      // Empty/length are gated by the disabled button + maxLength; the
+      // meaningful client-side rejection here is the blocked word.
       if (meta.reason === "blocked-word") setError(t.saveErrorBlockedWord);
-      return;
+      return false;
     }
     if (!songWithinSizeLimit(song)) {
       setError(t.saveErrorTooLarge);
-      return;
+      return false;
     }
+    return true;
+  };
 
+  const run = async (op: () => Promise<{ error: unknown }>) => {
+    if (!guard()) return;
     setSaving(true);
     setError(null);
     try {
-      const { error: dbError } = await supabase.from("songs").insert({
-        title: title.trim(),
-        author: author.trim(),
-        song_data: song,
-        user_id: userId,
-      });
+      const { error: dbError } = await op();
       if (dbError) {
         setError(t.saveErrorFailed);
         return;
@@ -60,6 +68,26 @@ export function SaveModal({ song, locale, userId, defaultAuthor = "", onClose }:
       setSaving(false);
     }
   };
+
+  const handleInsert = () =>
+    run(async () =>
+      supabase.from("songs").insert({
+        title: title.trim(),
+        author: author.trim(),
+        song_data: song,
+        user_id: userId,
+      })
+    );
+
+  const handleOverwrite = () =>
+    run(async () =>
+      supabase
+        .from("songs")
+        .update({ title: title.trim(), author: author.trim(), song_data: song })
+        .eq("id", existing!.id)
+    );
+
+  const canSave = !saving && !!title.trim() && !!author.trim();
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -93,13 +121,20 @@ export function SaveModal({ song, locale, userId, defaultAuthor = "", onClose }:
           <button className="modal-cancel" onClick={onClose}>
             {t.cancel}
           </button>
-          <button
-            className="modal-save"
-            onClick={handleSave}
-            disabled={saving || !title.trim() || !author.trim()}
-          >
-            {saving ? t.saving : t.save}
-          </button>
+          {existing ? (
+            <>
+              <button className="modal-cancel" onClick={handleInsert} disabled={!canSave}>
+                {t.saveAsNew}
+              </button>
+              <button className="modal-save" onClick={handleOverwrite} disabled={!canSave}>
+                {saving ? t.saving : t.overwrite}
+              </button>
+            </>
+          ) : (
+            <button className="modal-save" onClick={handleInsert} disabled={!canSave}>
+              {saving ? t.saving : t.save}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { Locale, Translations } from "@/lib/i18n";
+import { supabase } from "@/lib/supabase";
+import {
+  MAX_TITLE_LENGTH,
+  validateSongMeta,
+} from "@/lib/validation";
+
+interface Props {
+  id: string;
+  title: string;
+  author: string;
+  time: string;
+  gradient: string;
+  isOwner: boolean;
+  locale: Locale;
+  t: Translations;
+  onDeleted: (id: string) => void;
+  onRenamed: (id: string, title: string) => void;
+}
+
+type Mode = "view" | "rename" | "confirmDelete";
+
+export function SongCard({
+  id,
+  title,
+  author,
+  time,
+  gradient,
+  isOwner,
+  t,
+  onDeleted,
+  onRenamed,
+}: Props) {
+  const [mode, setMode] = useState<Mode>("view");
+  const [draft, setDraft] = useState(title);
+  const [busy, setBusy] = useState(false);
+
+  const saveRename = async () => {
+    const next = draft.trim();
+    // Reuse the same title rules as saving (length, empty, blocked word).
+    const meta = validateSongMeta({ title: next, author });
+    if (!meta.ok || next === title) {
+      setMode("view");
+      setDraft(title);
+      return;
+    }
+    setBusy(true);
+    const { error } = await supabase.from("songs").update({ title: next }).eq("id", id);
+    setBusy(false);
+    if (!error) {
+      onRenamed(id, next);
+      setMode("view");
+    }
+  };
+
+  const confirmDelete = async () => {
+    setBusy(true);
+    const { error } = await supabase.from("songs").delete().eq("id", id);
+    setBusy(false);
+    if (!error) onDeleted(id);
+    else setMode("view");
+  };
+
+  return (
+    <div className="song-card">
+      <div className="song-card-art" style={{ background: gradient }} />
+      <div className="song-card-body">
+        {mode === "rename" ? (
+          <div className="song-card-rename">
+            <input
+              className="song-card-rename-input"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              maxLength={MAX_TITLE_LENGTH}
+              autoFocus
+            />
+            <div className="song-card-rename-actions">
+              <button className="song-card-mini save" onClick={saveRename} disabled={busy}>
+                {t.save}
+              </button>
+              <button
+                className="song-card-mini"
+                onClick={() => {
+                  setMode("view");
+                  setDraft(title);
+                }}
+                disabled={busy}
+              >
+                {t.cancel}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="song-card-title">{title}</p>
+        )}
+
+        <p className="song-card-author">{author}</p>
+        <p className="song-card-time">{time}</p>
+
+        {mode === "confirmDelete" ? (
+          <div className="song-card-confirm">
+            <span className="song-card-confirm-label">{t.confirmDeleteSong}</span>
+            <div className="song-card-rename-actions">
+              <button className="song-card-mini danger" onClick={confirmDelete} disabled={busy}>
+                {t.confirmYes}
+              </button>
+              <button
+                className="song-card-mini"
+                onClick={() => setMode("view")}
+                disabled={busy}
+              >
+                {t.cancel}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <Link href={`/?load=${id}`} className="song-card-play">
+            {t.playBtn}
+          </Link>
+        )}
+
+        {isOwner && mode === "view" && (
+          <div className="song-card-owner">
+            <button className="song-card-mini" onClick={() => setMode("rename")}>
+              ✎ {t.rename}
+            </button>
+            <button className="song-card-mini danger" onClick={() => setMode("confirmDelete")}>
+              🗑 {t.deleteSong}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { Locale, Translations } from "@/lib/i18n";
+import type { Translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
 import {
   MAX_TITLE_LENGTH,
@@ -16,7 +16,6 @@ interface Props {
   time: string;
   gradient: string;
   isOwner: boolean;
-  locale: Locale;
   t: Translations;
   onDeleted: (id: string) => void;
   onRenamed: (id: string, title: string) => void;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -333,6 +333,9 @@ export default function Home() {
               ? { id: loadedSong.id, title: loadedSong.title, author: loadedSong.author }
               : null
           }
+          onOverwritten={(title, author) =>
+            setLoadedSong((prev) => (prev ? { ...prev, title, author } : prev))
+          }
           onClose={() => setIsSaveModalOpen(false)}
         />
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,13 @@ export default function Home() {
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isLockMode, setIsLockMode] = useState(false);
+  // The song loaded via ?load=<id>, so its owner can overwrite it on save.
+  const [loadedSong, setLoadedSong] = useState<{
+    id: string;
+    title: string;
+    author: string;
+    userId: string | null;
+  } | null>(null);
 
   const gridRef = useRef<HTMLDivElement>(null);
   const gridContainerRef = useRef<HTMLDivElement>(null);
@@ -60,12 +67,18 @@ export default function Home() {
     if (!loadId) return;
     supabase
       .from("songs")
-      .select("song_data")
+      .select("id, title, author, song_data, user_id")
       .eq("id", loadId)
       .single()
       .then(({ data }) => {
         if (data?.song_data) {
           setSong(migrateSong(data.song_data));
+          setLoadedSong({
+            id: data.id,
+            title: data.title,
+            author: data.author,
+            userId: data.user_id ?? null,
+          });
           window.history.replaceState({}, "", "/");
         }
       });
@@ -315,6 +328,11 @@ export default function Home() {
           locale={locale}
           userId={user?.id ?? null}
           defaultAuthor={authDisplayName(user)}
+          existing={
+            user && loadedSong && loadedSong.userId === user.id
+              ? { id: loadedSong.id, title: loadedSong.title, author: loadedSong.author }
+              : null
+          }
           onClose={() => setIsSaveModalOpen(false)}
         />
       )}

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -124,7 +124,6 @@ export default function SongsPage() {
                 time={timeAgo(song.created_at, locale)}
                 gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
                 isOwner={!!user && song.user_id === user.id}
-                locale={locale}
                 t={t}
                 onDeleted={handleDeleted}
                 onRenamed={handleRenamed}

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/hooks/useAuth";
 import { AuthButton } from "@/app/components/AuthButton";
+import { SongCard } from "@/app/components/SongCard";
 import type { Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
@@ -16,7 +17,10 @@ type FeedSong = {
   author: string;
   created_at: string;
   song_data: Song;
+  user_id: string | null;
 };
+
+type View = "all" | "mine";
 
 const CARD_GRADIENTS = [
   "linear-gradient(135deg, #ff6b6b, #feca57)",
@@ -43,17 +47,35 @@ export default function SongsPage() {
   const { user, signInWithGoogle, signOut } = useAuth();
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<View>("all");
+
+  // "mine" only applies while signed in (no corrective setState needed).
+  const effectiveView: View = user ? view : "all";
 
   useEffect(() => {
-    supabase
+    let query = supabase
       .from("songs")
-      .select("id, title, author, created_at, song_data")
+      .select("id, title, author, created_at, song_data, user_id");
+    if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
+    query
       .order("created_at", { ascending: false })
       .limit(50)
       .then(({ data }) => {
         setSongs((data as FeedSong[]) ?? []);
         setLoading(false);
       });
+  }, [effectiveView, user]);
+
+  // Client-side filter keeps the view correct instantly while a refetch lands.
+  const displayed =
+    effectiveView === "mine" && user ? songs.filter((s) => s.user_id === user.id) : songs;
+
+  const handleDeleted = useCallback((id: string) => {
+    setSongs((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const handleRenamed = useCallback((id: string, title: string) => {
+    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, title } : s)));
   }, []);
 
   return (
@@ -70,27 +92,43 @@ export default function SongsPage() {
       </header>
 
       <main className="songs-main">
+        {user && (
+          <div className="songs-tabs">
+            <button
+              className={`songs-tab ${effectiveView === "all" ? "active" : ""}`}
+              onClick={() => setView("all")}
+            >
+              {t.feedAll}
+            </button>
+            <button
+              className={`songs-tab ${effectiveView === "mine" ? "active" : ""}`}
+              onClick={() => setView("mine")}
+            >
+              {t.feedMine}
+            </button>
+          </div>
+        )}
+
         {loading ? (
           <p className="songs-status">{t.loading}</p>
-        ) : songs.length === 0 ? (
-          <p className="songs-status">{t.noSongs}</p>
+        ) : displayed.length === 0 ? (
+          <p className="songs-status">{effectiveView === "mine" ? t.noMySongs : t.noSongs}</p>
         ) : (
           <div className="songs-grid">
-            {songs.map((song, i) => (
-              <div key={song.id} className="song-card">
-                <div
-                  className="song-card-art"
-                  style={{ background: CARD_GRADIENTS[i % CARD_GRADIENTS.length] }}
-                />
-                <div className="song-card-body">
-                  <p className="song-card-title">{song.title}</p>
-                  <p className="song-card-author">{song.author}</p>
-                  <p className="song-card-time">{timeAgo(song.created_at, locale)}</p>
-                  <Link href={`/?load=${song.id}`} className="song-card-play">
-                    {t.playBtn}
-                  </Link>
-                </div>
-              </div>
+            {displayed.map((song, i) => (
+              <SongCard
+                key={song.id}
+                id={song.id}
+                title={song.title}
+                author={song.author}
+                time={timeAgo(song.created_at, locale)}
+                gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
+                isOwner={!!user && song.user_id === user.id}
+                locale={locale}
+                t={t}
+                onDeleted={handleDeleted}
+                onRenamed={handleRenamed}
+              />
             ))}
           </div>
         )}

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -142,6 +142,124 @@
   box-shadow: 0 6px 16px rgba(0, 200, 83, 0.4);
 }
 
+/* My/All filter tabs */
+.songs-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.songs-tab {
+  padding: 8px 18px;
+  border-radius: 20px;
+  border: 1.5px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.songs-tab.active {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-color: transparent;
+  color: white;
+}
+
+/* Owner controls on a song card */
+.song-card-owner {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.song-card-mini {
+  flex: 1;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.song-card-mini:hover {
+  background: var(--grid-line);
+}
+
+.song-card-mini.save {
+  background: linear-gradient(135deg, #11998e, #38ef7d);
+  color: white;
+  border-color: transparent;
+}
+
+.song-card-mini.danger {
+  color: #ee5253;
+  border-color: #ee5253;
+}
+
+.song-card-mini.danger:hover {
+  background: #ee5253;
+  color: white;
+}
+
+.song-card-mini:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inline rename */
+.song-card-rename {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.song-card-rename-input {
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 15px;
+  font-weight: 700;
+  outline: none;
+}
+
+.song-card-rename-input:focus {
+  border-color: #667eea;
+}
+
+.song-card-rename-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.song-card-rename-actions .song-card-mini {
+  flex: 1;
+}
+
+/* Inline delete confirm */
+.song-card-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.song-card-confirm-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ee5253;
+}
+
 @media (max-width: 480px) {
   .songs-header {
     padding: 12px 16px;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -34,6 +34,8 @@ export type Translations = {
   saveErrorBlockedWord: string;
   saveErrorTooLarge: string;
   saveErrorFailed: string;
+  overwrite: string;
+  saveAsNew: string;
   // Songs page
   backToCreate: string;
   pageTitle: string;
@@ -86,6 +88,8 @@ export const translations: Record<Locale, Translations> = {
     saveErrorBlockedWord: "That title or name can't be used.",
     saveErrorTooLarge: "This song is too large to save.",
     saveErrorFailed: "Couldn't save. Please try again.",
+    overwrite: "Update",
+    saveAsNew: "Save as new",
     backToCreate: "← Create",
     pageTitle: "Everyone's Songs",
     loading: "Loading...",
@@ -134,6 +138,8 @@ export const translations: Record<Locale, Translations> = {
     saveErrorBlockedWord: "つかえない ことばが はいっています。",
     saveErrorTooLarge: "きょくが おおきすぎて ほぞんできません。",
     saveErrorFailed: "ほぞんに しっぱいしました。もういちど ためしてね。",
+    overwrite: "うわがき保存",
+    saveAsNew: "新しく保存",
     backToCreate: "← つくる",
     pageTitle: "みんなの曲",
     loading: "よみこみちゅう...",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -39,7 +39,13 @@ export type Translations = {
   pageTitle: string;
   loading: string;
   noSongs: string;
+  noMySongs: string;
   playBtn: string;
+  feedAll: string;
+  feedMine: string;
+  rename: string;
+  deleteSong: string;
+  confirmDeleteSong: string;
   justNow: string;
   minutesAgo: (n: number) => string;
   hoursAgo: (n: number) => string;
@@ -84,7 +90,13 @@ export const translations: Record<Locale, Translations> = {
     pageTitle: "Everyone's Songs",
     loading: "Loading...",
     noSongs: "No songs yet. Be the first to save one!",
+    noMySongs: "You haven't saved any songs yet.",
     playBtn: "Play",
+    feedAll: "All",
+    feedMine: "Mine",
+    rename: "Rename",
+    deleteSong: "Delete",
+    confirmDeleteSong: "Delete this song?",
     justNow: "just now",
     minutesAgo: (n) => `${n}m ago`,
     hoursAgo: (n) => `${n}h ago`,
@@ -126,7 +138,13 @@ export const translations: Record<Locale, Translations> = {
     pageTitle: "みんなの曲",
     loading: "よみこみちゅう...",
     noSongs: "まだ曲がありません。さいしょに保存してみよう！",
+    noMySongs: "まだ じぶんの曲が ありません。",
     playBtn: "あそぶ",
+    feedAll: "みんな",
+    feedMine: "じぶん",
+    rename: "なまえをかえる",
+    deleteSong: "けす",
+    confirmDeleteSong: "この曲を けしますか？",
     justNow: "たったいま",
     minutesAgo: (n) => `${n}分まえ`,
     hoursAgo: (n) => `${n}時間まえ`,


### PR DESCRIPTION
Closes #35

## What

#34 の所有権/RLS を活かした「自分の曲」管理 一式。

### /songs（一覧管理）
- **みんな / じぶん フィルタ**（ログイン時のみ）。「じぶん」は `user_id` で再取得＋クライアント即時フィルタ
- **所有カードのみ**にインライン **改名**（保存と同じ検証）／**削除（確認つき）**。非所有カードは操作なし
- `<SongCard>` コンポーネントに抽出

### エディタ（上書き保存）
- ログイン中に**自分の曲を `?load=` で開く**と、エディタがその曲を記憶
- 保存ダイアログで **「うわがき保存 / Update」**（既存行を update）と **「新しく保存 / Save as new」** を選べる
- 匿名・他人の曲では従来どおり単一の「ほぞん」ボタン

i18n（ja/en）追加、更新/削除は RLS で「所有者の表示中の行のみ」に制限済み（サーバー担保）。

## Verification

- 匿名: `/songs` にタブも所有者操作も出ない／保存ダイアログは単一ボタン（回帰なし）／フィード読込OK／コンソールエラーなし
- `pnpm lint` / `tsc` / `build` グリーン、47テストパス
- リファクタ: `SongCard` の未使用 `locale` prop を削除
- ログイン時の改名/削除/上書きの実動作は、あなたのアカウントでの確認後に DB を検証します（サンドボックスでは実ログイン不可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)