### PR TITLE
feat: 曲テンプレート機能（ロールなし）(#36)

### DIFF
--- a/src/app/components/SettingsPanel.tsx
+++ b/src/app/components/SettingsPanel.tsx
@@ -20,6 +20,7 @@ interface Props {
   isNotePanelOpen: boolean;
   isConfirmingReset: boolean;
   isLockMode: boolean;
+  canLock: boolean;
   onToggleLockMode: () => void;
   onBpmChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onPitchBoundChange: (bound: "min" | "max", direction: "up" | "down") => void;
@@ -40,6 +41,7 @@ export function SettingsPanel({
   isNotePanelOpen,
   isConfirmingReset,
   isLockMode,
+  canLock,
   onToggleLockMode,
   onBpmChange,
   onPitchBoundChange,
@@ -167,15 +169,17 @@ export function SettingsPanel({
             <span className="notes-panel-arrow">{isNotePanelOpen ? "▲" : "▼"}</span>
           </button>
         </div>
-        <div className="control-group">
-          <button
-            className={`lock-mode-btn ${isLockMode ? "active" : ""}`}
-            onClick={onToggleLockMode}
-            aria-pressed={isLockMode}
-          >
-            {t.lockMode}
-          </button>
-        </div>
+        {canLock && (
+          <div className="control-group">
+            <button
+              className={`lock-mode-btn ${isLockMode ? "active" : ""}`}
+              onClick={onToggleLockMode}
+              aria-pressed={isLockMode}
+            >
+              {t.lockMode}
+            </button>
+          </div>
+        )}
       </div>
       <div className="settings-danger">
         {isConfirmingReset ? (

--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -16,9 +16,11 @@ interface Props {
   time: string;
   gradient: string;
   isOwner: boolean;
+  isTemplate: boolean;
   t: Translations;
   onDeleted: (id: string) => void;
   onRenamed: (id: string, title: string) => void;
+  onTemplateToggled: (id: string, isTemplate: boolean) => void;
 }
 
 type Mode = "view" | "rename" | "confirmDelete";
@@ -30,9 +32,11 @@ export function SongCard({
   time,
   gradient,
   isOwner,
+  isTemplate,
   t,
   onDeleted,
   onRenamed,
+  onTemplateToggled,
 }: Props) {
   const [mode, setMode] = useState<Mode>("view");
   const [draft, setDraft] = useState(title);
@@ -64,9 +68,22 @@ export function SongCard({
     else setMode("view");
   };
 
+  const toggleTemplate = async () => {
+    const next = !isTemplate;
+    setBusy(true);
+    const { error } = await supabase
+      .from("songs")
+      .update({ is_template: next })
+      .eq("id", id);
+    setBusy(false);
+    if (!error) onTemplateToggled(id, next);
+  };
+
   return (
     <div className="song-card">
-      <div className="song-card-art" style={{ background: gradient }} />
+      <div className="song-card-art" style={{ background: gradient }}>
+        {isTemplate && <span className="song-card-template-badge">{t.templateBadge}</span>}
+      </div>
       <div className="song-card-body">
         {mode === "rename" ? (
           <div className="song-card-rename">
@@ -123,14 +140,23 @@ export function SongCard({
         )}
 
         {isOwner && mode === "view" && (
-          <div className="song-card-owner">
-            <button className="song-card-mini" onClick={() => setMode("rename")}>
-              ✎ {t.rename}
+          <>
+            <button
+              className={`song-card-mini template ${isTemplate ? "active" : ""}`}
+              onClick={toggleTemplate}
+              disabled={busy}
+            >
+              {isTemplate ? `★ ${t.templateOff}` : `☆ ${t.templateOn}`}
             </button>
-            <button className="song-card-mini danger" onClick={() => setMode("confirmDelete")}>
-              🗑 {t.deleteSong}
-            </button>
-          </div>
+            <div className="song-card-owner">
+              <button className="song-card-mini" onClick={() => setMode("rename")}>
+                ✎ {t.rename}
+              </button>
+              <button className="song-card-mini danger" onClick={() => setMode("confirmDelete")}>
+                🗑 {t.deleteSong}
+              </button>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,6 +168,12 @@ export default function Home() {
     [song, setSong, pushHistory]
   );
 
+  // Locks may only be edited by the song's author. Loading someone else's
+  // song (e.g. a template) makes the locks read-only, so a student can't
+  // unlock the fixed backing in their copy. A fresh, unsaved song is editable.
+  const canLock = !loadedSong || (!!user && loadedSong.userId === user.id);
+  const lockActive = isLockMode && canLock;
+
   const { isDragging, getMelodyCellHandlers, getDrumCellHandlers, containerHandlers } =
     useDragInteraction({
       gridRef,
@@ -178,7 +184,7 @@ export default function Home() {
       onDragStart: handleDragStart,
       onDrumToggle: handleDrumToggle,
       findNoteAt,
-      isLockMode,
+      isLockMode: lockActive,
       onToggleMelodyLock: handleToggleMelodyLock,
       onToggleDrumLock: handleToggleDrumLock,
     });
@@ -256,7 +262,7 @@ export default function Home() {
 
   return (
     <div
-      className={`app ${isDragging ? "dragging" : ""} ${isLockMode ? "lock-mode" : ""}`}
+      className={`app ${isDragging ? "dragging" : ""} ${lockActive ? "lock-mode" : ""}`}
       onMouseMove={containerHandlers.onMouseMove}
       onMouseUp={containerHandlers.onMouseUp}
       onMouseLeave={containerHandlers.onMouseLeave}
@@ -288,7 +294,8 @@ export default function Home() {
           isPlaying={isPlaying}
           isNotePanelOpen={isNotePanelOpen}
           isConfirmingReset={isConfirmingReset}
-          isLockMode={isLockMode}
+          isLockMode={lockActive}
+          canLock={canLock}
           onToggleLockMode={() => setIsLockMode((prev) => !prev)}
           onBpmChange={handleBpmChange}
           onPitchBoundChange={handlePitchBoundChange}

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -18,9 +18,10 @@ type FeedSong = {
   created_at: string;
   song_data: Song;
   user_id: string | null;
+  is_template: boolean;
 };
 
-type View = "all" | "mine";
+type View = "all" | "mine" | "templates";
 
 const CARD_GRADIENTS = [
   "linear-gradient(135deg, #ff6b6b, #feca57)",
@@ -49,14 +50,15 @@ export default function SongsPage() {
   const [loading, setLoading] = useState(true);
   const [view, setView] = useState<View>("all");
 
-  // "mine" only applies while signed in (no corrective setState needed).
-  const effectiveView: View = user ? view : "all";
+  // "mine" needs sign-in; "all" and "templates" are open to everyone.
+  const effectiveView: View = !user && view === "mine" ? "all" : view;
 
   useEffect(() => {
     let query = supabase
       .from("songs")
-      .select("id, title, author, created_at, song_data, user_id");
+      .select("id, title, author, created_at, song_data, user_id, is_template");
     if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
+    else if (effectiveView === "templates") query = query.eq("is_template", true);
     query
       .order("created_at", { ascending: false })
       .limit(50)
@@ -68,7 +70,11 @@ export default function SongsPage() {
 
   // Client-side filter keeps the view correct instantly while a refetch lands.
   const displayed =
-    effectiveView === "mine" && user ? songs.filter((s) => s.user_id === user.id) : songs;
+    effectiveView === "mine" && user
+      ? songs.filter((s) => s.user_id === user.id)
+      : effectiveView === "templates"
+        ? songs.filter((s) => s.is_template)
+        : songs;
 
   const handleDeleted = useCallback((id: string) => {
     setSongs((prev) => prev.filter((s) => s.id !== id));
@@ -76,6 +82,10 @@ export default function SongsPage() {
 
   const handleRenamed = useCallback((id: string, title: string) => {
     setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, title } : s)));
+  }, []);
+
+  const handleTemplateToggled = useCallback((id: string, isTemplate: boolean) => {
+    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, is_template: isTemplate } : s)));
   }, []);
 
   return (
@@ -92,27 +102,39 @@ export default function SongsPage() {
       </header>
 
       <main className="songs-main">
-        {user && (
-          <div className="songs-tabs">
-            <button
-              className={`songs-tab ${effectiveView === "all" ? "active" : ""}`}
-              onClick={() => setView("all")}
-            >
-              {t.feedAll}
-            </button>
+        <div className="songs-tabs">
+          <button
+            className={`songs-tab ${effectiveView === "all" ? "active" : ""}`}
+            onClick={() => setView("all")}
+          >
+            {t.feedAll}
+          </button>
+          <button
+            className={`songs-tab ${effectiveView === "templates" ? "active" : ""}`}
+            onClick={() => setView("templates")}
+          >
+            {t.feedTemplates}
+          </button>
+          {user && (
             <button
               className={`songs-tab ${effectiveView === "mine" ? "active" : ""}`}
               onClick={() => setView("mine")}
             >
               {t.feedMine}
             </button>
-          </div>
-        )}
+          )}
+        </div>
 
         {loading ? (
           <p className="songs-status">{t.loading}</p>
         ) : displayed.length === 0 ? (
-          <p className="songs-status">{effectiveView === "mine" ? t.noMySongs : t.noSongs}</p>
+          <p className="songs-status">
+            {effectiveView === "mine"
+              ? t.noMySongs
+              : effectiveView === "templates"
+                ? t.noTemplates
+                : t.noSongs}
+          </p>
         ) : (
           <div className="songs-grid">
             {displayed.map((song, i) => (
@@ -124,9 +146,11 @@ export default function SongsPage() {
                 time={timeAgo(song.created_at, locale)}
                 gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
                 isOwner={!!user && song.user_id === user.id}
+                isTemplate={song.is_template}
                 t={t}
                 onDeleted={handleDeleted}
                 onRenamed={handleRenamed}
+                onTemplateToggled={handleTemplateToggled}
               />
             ))}
           </div>

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -59,6 +59,7 @@ export default function SongsPage() {
       .select("id, title, author, created_at, song_data, user_id, is_template");
     if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
     else if (effectiveView === "templates") query = query.eq("is_template", true);
+    else query = query.eq("is_template", false); // "all" excludes templates
     query
       .order("created_at", { ascending: false })
       .limit(50)
@@ -74,7 +75,7 @@ export default function SongsPage() {
       ? songs.filter((s) => s.user_id === user.id)
       : effectiveView === "templates"
         ? songs.filter((s) => s.is_template)
-        : songs;
+        : songs.filter((s) => !s.is_template);
 
   const handleDeleted = useCallback((id: string) => {
     setSongs((prev) => prev.filter((s) => s.id !== id));

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -90,6 +90,20 @@
 .song-card-art {
   height: 90px;
   flex-shrink: 0;
+  position: relative;
+}
+
+.song-card-template-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.55);
+  color: white;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
 }
 
 .song-card-body {
@@ -211,6 +225,18 @@
 .song-card-mini:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Template toggle (full-width, above rename/delete) */
+.song-card-mini.template {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.song-card-mini.template.active {
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+  color: white;
+  border-color: transparent;
 }
 
 /* Inline rename */

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -45,6 +45,11 @@ export type Translations = {
   playBtn: string;
   feedAll: string;
   feedMine: string;
+  feedTemplates: string;
+  noTemplates: string;
+  templateBadge: string;
+  templateOn: string;
+  templateOff: string;
   rename: string;
   deleteSong: string;
   confirmDeleteSong: string;
@@ -98,6 +103,11 @@ export const translations: Record<Locale, Translations> = {
     playBtn: "Play",
     feedAll: "All",
     feedMine: "Mine",
+    feedTemplates: "Templates",
+    noTemplates: "No templates yet.",
+    templateBadge: "Template",
+    templateOn: "Make template",
+    templateOff: "Unset template",
     rename: "Rename",
     deleteSong: "Delete",
     confirmDeleteSong: "Delete this song?",
@@ -148,6 +158,11 @@ export const translations: Record<Locale, Translations> = {
     playBtn: "あそぶ",
     feedAll: "みんな",
     feedMine: "じぶん",
+    feedTemplates: "テンプレ",
+    noTemplates: "まだ テンプレートが ありません。",
+    templateBadge: "テンプレ",
+    templateOn: "テンプレにする",
+    templateOff: "テンプレ解除",
     rename: "なまえをかえる",
     deleteSong: "けす",
     confirmDeleteSong: "この曲を けしますか？",

--- a/supabase/migrations/0003_songs_templates.sql
+++ b/supabase/migrations/0003_songs_templates.sql
@@ -1,0 +1,23 @@
+-- #36 templates: any signed-in owner can publish one of their songs as a
+-- template for others (incl. anonymous students) to start from.
+-- Applied to the BeatBubble Supabase project via the management API.
+
+alter table public.songs
+  add column if not exists is_template boolean not null default false;
+
+create index if not exists songs_is_template_idx
+  on public.songs(is_template) where is_template;
+
+-- Harden insert so a template can only be created by its (signed-in) owner.
+-- Normal saves never set is_template, so anonymous saves are unaffected.
+drop policy if exists "insert own or anon" on public.songs;
+create policy "insert own or anon" on public.songs
+  for insert to public
+  with check (
+    hidden = false
+    and (user_id is null or user_id = auth.uid())
+    and (is_template = false or user_id = auth.uid())
+  );
+
+-- (The existing "owner update" policy already lets an owner toggle is_template
+--  on their own visible rows; the public read policy exposes templates to all.)


### PR DESCRIPTION
Closes #36

## What

ログインユーザーが自分の曲（例: ベースをロックした曲）を**テンプレート**として公開でき、**匿名の生徒を含む誰でも**「テンプレ」タブから選んで上に作れるように。**先生/生徒のロールは作らず**、「ログイン＝先生／匿名＝生徒」という自然な役割分担で実現。本格的な教室管理は #48 に分離。

## DB（Supabase 適用済み・`supabase/migrations/0003`）
- `songs.is_template`（既定 false）＋部分インデックス
- insert ポリシー強化: `is_template=true` は所有者（ログイン）のみ設定可。匿名の通常保存は不変

## クライアント
- `/songs` に **テンプレ タブ**（全員に表示）を追加（みんな／じぶん と並ぶ。じぶんは従来どおりログイン時のみ）。`is_template` で取得＋即時クライアントフィルタ
- `SongCard`: 全員に見える **テンプレ バッジ** ＋ 所有者のみの **★テンプレにする/解除** トグル
- i18n（ja/en）

更新は RLS で所有者の表示中行のみ。テンプレ公開/解除＝所有行の update。

## Verification
- 匿名: タブ [みんな, テンプレ]（じぶんは非表示）、テンプレは空メッセージ表示、所有者操作なし、みんなは一覧表示、コンソールエラーなし
- `pnpm lint` / `tsc` / `build` グリーン、47テストパス
- 所有者の★トグル・テンプレ反映は、あなたのログインでの確認後に DB 検証します（サンドボックスでは実ログイン不可）

## 使い方（テスト手順）
1. ログイン → 自分の曲（ベースをロックしておくと教育効果◎）を保存
2. `/songs` 「じぶん」→ その曲で **☆テンプレにする** → ★ になり「テンプレ」タブに出る
3. ログアウト（＝生徒役）→ 「テンプレ」タブ → あそぶ → ロックされた伴奏ごと読み込まれ、上に作れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)