### PR TITLE
fix: ログアウトに確認モーダルを追加

### DIFF
--- a/src/app/components/AuthButton.tsx
+++ b/src/app/components/AuthButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import type { Translations } from "@/lib/i18n";
 import { authDisplayName } from "@/hooks/useAuth";
@@ -14,13 +15,42 @@ interface Props {
 // Shared login/logout control for the editor and songs headers.
 export function AuthButton({ user, t, onSignIn, onSignOut }: Props) {
   const name = authDisplayName(user);
-  return name ? (
-    <button className="auth-btn" onClick={onSignOut} title={name}>
-      {t.logout}
-    </button>
-  ) : (
-    <button className="auth-btn" onClick={onSignIn}>
-      {t.login}
-    </button>
+  const [confirming, setConfirming] = useState(false);
+
+  if (!name) {
+    return (
+      <button className="auth-btn" onClick={onSignIn}>
+        {t.login}
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <button className="auth-btn" onClick={() => setConfirming(true)} title={name}>
+        {t.logout}
+      </button>
+      {confirming && (
+        <div className="modal-overlay" onClick={() => setConfirming(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h2 className="modal-title">{t.logoutConfirm}</h2>
+            <div className="modal-actions">
+              <button className="modal-cancel" onClick={() => setConfirming(false)}>
+                {t.cancel}
+              </button>
+              <button
+                className="modal-save"
+                onClick={() => {
+                  setConfirming(false);
+                  onSignOut();
+                }}
+              >
+                {t.logout}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -61,6 +61,7 @@ export type Translations = {
   switchLocale: string;
   login: string;
   logout: string;
+  logoutConfirm: string;
 };
 
 export const translations: Record<Locale, Translations> = {
@@ -118,6 +119,7 @@ export const translations: Record<Locale, Translations> = {
     switchLocale: "日本語",
     login: "Log in",
     logout: "Log out",
+    logoutConfirm: "Log out?",
   },
   ja: {
     play: "えんそう",
@@ -173,5 +175,6 @@ export const translations: Record<Locale, Translations> = {
     switchLocale: "EN",
     login: "ログイン",
     logout: "ログアウト",
+    logoutConfirm: "本当にログアウトしますか？",
   },
 };


### PR DESCRIPTION
## 症状
「ログアウト」を押すと**無確認で即ログアウト**し、画面遷移だけ起きて気づきにくい。

## 修正
ログアウトボタン押下で「**本当にログアウトしますか？**」確認モーダルを表示し、「ログアウト」を選んだときだけ実行（「キャンセル」で閉じる）。共有コンポーネント `AuthButton` に実装したので、**エディタ・/songs 両ヘッダー**に効く。

- `AuthButton`: ローカル確認状態＋既存のモーダルスタイルを再利用（背景クリック/キャンセルで閉じる）
- i18n: `logoutConfirm`（ja/en）

## Verification
- 匿名: ログインボタンは従来どおり、余計なモーダルなし（回帰なし）
- `pnpm lint` / `tsc` / `build` グリーン、47テストパス
- 確認モーダル本体はログイン状態でのみ表示されるため、実機（ログイン）でのご確認をお願いします（サンドボックスでは実ログイン不可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)