### PR TITLE
feat: 曲カードに「リンクをコピー」追加（#37 フェーズA①）

### DIFF
--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -41,6 +41,17 @@ export function SongCard({
   const [mode, setMode] = useState<Mode>("view");
   const [draft, setDraft] = useState(title);
   const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/?load=${id}`);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable (e.g. insecure context) — silently ignore
+    }
+  };
 
   const saveRename = async () => {
     const next = draft.trim();
@@ -137,6 +148,12 @@ export function SongCard({
           <Link href={`/?load=${id}`} className="song-card-play">
             {t.playBtn}
           </Link>
+        )}
+
+        {mode === "view" && (
+          <button className="song-card-share" onClick={copyLink}>
+            🔗 {copied ? t.linkCopied : t.copyLink}
+          </button>
         )}
 
         {isOwner && mode === "view" && (

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -156,6 +156,25 @@
   box-shadow: 0 6px 16px rgba(0, 200, 83, 0.4);
 }
 
+/* Copy-share-link button (shown to everyone) */
+.song-card-share {
+  margin-top: 8px;
+  width: 100%;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.song-card-share:hover {
+  background: var(--grid-line);
+}
+
 /* My/All filter tabs */
 .songs-tabs {
   display: flex;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -43,6 +43,8 @@ export type Translations = {
   noSongs: string;
   noMySongs: string;
   playBtn: string;
+  copyLink: string;
+  linkCopied: string;
   feedAll: string;
   feedMine: string;
   feedTemplates: string;
@@ -102,6 +104,8 @@ export const translations: Record<Locale, Translations> = {
     noSongs: "No songs yet. Be the first to save one!",
     noMySongs: "You haven't saved any songs yet.",
     playBtn: "Play",
+    copyLink: "Copy link",
+    linkCopied: "Copied!",
     feedAll: "All",
     feedMine: "Mine",
     feedTemplates: "Templates",
@@ -158,6 +162,8 @@ export const translations: Record<Locale, Translations> = {
     noSongs: "まだ曲がありません。さいしょに保存してみよう！",
     noMySongs: "まだ じぶんの曲が ありません。",
     playBtn: "あそぶ",
+    copyLink: "リンクをコピー",
+    linkCopied: "コピーしました！",
     feedAll: "みんな",
     feedMine: "じぶん",
     feedTemplates: "テンプレ",


### PR DESCRIPTION
Refs #37

## What

#37（書き出し・共有強化）の**フェーズA①＝共有リンクのコピー**。`/songs` の各カードに **🔗 リンクをコピー** ボタンを追加（全員に表示）。`${origin}/?load=<id>` をクリップボードにコピーし、「コピーしました！」を短時間表示。

## Changes
- `SongCard`: コピー処理＋一時フィードバック状態（クリップボード不可時は握りつぶし）
- i18n: `copyLink` / `linkCopied`（ja/en）
- CSS: `.song-card-share`

## Verification
- 匿名: 8カードすべてにボタン表示（スクショ確認）、コンソールエラーなし
- `clipboard.writeText` はヘッドレスプレビューでは `NotAllowedError`（実ユーザー操作が必要）→ **実ブラウザのクリックでコピー動作**。実機での最終確認をお願いします
- `pnpm lint` / `tsc` / `build` グリーン、47テストパス

## 次（フェーズA②・別PR）
- **WAV 書き出し**（エディタ）: OfflineAudioContext で1ループ＋余韻をレンダリング → WAV エンコード → ダウンロード。エンジンのシンセを ctx 引数化して再利用（再生音と一致させる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)