### PR TITLE
feat: 曲カードをコンパクト化（管理操作を⋯メニューに集約）

### DIFF
--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import type { Translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
-import {
-  MAX_TITLE_LENGTH,
-  validateSongMeta,
-} from "@/lib/validation";
+import { MAX_TITLE_LENGTH, validateSongMeta } from "@/lib/validation";
 
 interface Props {
   id: string;
@@ -42,6 +39,17 @@ export function SongCard({
   const [draft, setDraft] = useState(title);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [menuOpen]);
 
   const copyLink = async () => {
     try {
@@ -55,7 +63,6 @@ export function SongCard({
 
   const saveRename = async () => {
     const next = draft.trim();
-    // Reuse the same title rules as saving (length, empty, blocked word).
     const meta = validateSongMeta({ title: next, author });
     if (!meta.ok || next === title) {
       setMode("view");
@@ -81,11 +88,9 @@ export function SongCard({
 
   const toggleTemplate = async () => {
     const next = !isTemplate;
+    setMenuOpen(false);
     setBusy(true);
-    const { error } = await supabase
-      .from("songs")
-      .update({ is_template: next })
-      .eq("id", id);
+    const { error } = await supabase.from("songs").update({ is_template: next }).eq("id", id);
     setBusy(false);
     if (!error) onTemplateToggled(id, next);
   };
@@ -94,7 +99,47 @@ export function SongCard({
     <div className="song-card">
       <div className="song-card-art" style={{ background: gradient }}>
         {isTemplate && <span className="song-card-template-badge">{t.templateBadge}</span>}
+        {isOwner && (
+          <div className="song-card-menu" ref={menuRef}>
+            <button
+              className="song-card-kebab"
+              aria-label={t.songMenu}
+              aria-haspopup="true"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((o) => !o)}
+            >
+              ⋯
+            </button>
+            {menuOpen && (
+              <div className="song-card-menu-pop" role="menu">
+                <button role="menuitem" onClick={toggleTemplate} disabled={busy}>
+                  {isTemplate ? `★ ${t.templateOff}` : `☆ ${t.templateOn}`}
+                </button>
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setMode("rename");
+                  }}
+                >
+                  ✎ {t.rename}
+                </button>
+                <button
+                  role="menuitem"
+                  className="danger"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setMode("confirmDelete");
+                  }}
+                >
+                  🗑 {t.deleteSong}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
       <div className="song-card-body">
         {mode === "rename" ? (
           <div className="song-card-rename">
@@ -125,8 +170,9 @@ export function SongCard({
           <p className="song-card-title">{title}</p>
         )}
 
-        <p className="song-card-author">{author}</p>
-        <p className="song-card-time">{time}</p>
+        <p className="song-card-meta">
+          {author} ・ {time}
+        </p>
 
         {mode === "confirmDelete" ? (
           <div className="song-card-confirm">
@@ -135,45 +181,25 @@ export function SongCard({
               <button className="song-card-mini danger" onClick={confirmDelete} disabled={busy}>
                 {t.confirmYes}
               </button>
-              <button
-                className="song-card-mini"
-                onClick={() => setMode("view")}
-                disabled={busy}
-              >
+              <button className="song-card-mini" onClick={() => setMode("view")} disabled={busy}>
                 {t.cancel}
               </button>
             </div>
           </div>
         ) : (
-          <Link href={`/?load=${id}`} className="song-card-play">
-            {t.playBtn}
-          </Link>
-        )}
-
-        {mode === "view" && (
-          <button className="song-card-share" onClick={copyLink}>
-            🔗 {copied ? t.linkCopied : t.copyLink}
-          </button>
-        )}
-
-        {isOwner && mode === "view" && (
-          <>
+          <div className="song-card-actions">
+            <Link href={`/?load=${id}`} className="song-card-play">
+              {t.playBtn}
+            </Link>
             <button
-              className={`song-card-mini template ${isTemplate ? "active" : ""}`}
-              onClick={toggleTemplate}
-              disabled={busy}
+              className="song-card-copy"
+              onClick={copyLink}
+              aria-label={copied ? t.linkCopied : t.copyLink}
+              title={copied ? t.linkCopied : t.copyLink}
             >
-              {isTemplate ? `★ ${t.templateOff}` : `☆ ${t.templateOn}`}
+              {copied ? "✓" : "🔗"}
             </button>
-            <div className="song-card-owner">
-              <button className="song-card-mini" onClick={() => setMode("rename")}>
-                ✎ {t.rename}
-              </button>
-              <button className="song-card-mini danger" onClick={() => setMode("confirmDelete")}>
-                🗑 {t.deleteSong}
-              </button>
-            </div>
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -75,7 +75,7 @@
 .song-card {
   background: var(--grid-bg);
   border-radius: 20px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;
@@ -91,6 +91,67 @@
   height: 90px;
   flex-shrink: 0;
   position: relative;
+  border-radius: 20px 20px 0 0;
+}
+
+.song-card-kebab {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.song-card-menu-pop {
+  position: absolute;
+  top: 42px;
+  right: 8px;
+  z-index: 5;
+  min-width: 150px;
+  background: var(--header-bg);
+  border: 1px solid var(--grid-line);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.song-card-menu-pop button {
+  text-align: left;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.song-card-menu-pop button:hover {
+  background: var(--grid-line);
+}
+
+.song-card-menu-pop button.danger {
+  color: #ee5253;
+}
+
+.song-card-menu-pop button.danger:hover {
+  background: #ee5253;
+  color: #fff;
 }
 
 .song-card-template-badge {
@@ -125,20 +186,23 @@
   margin-bottom: 2px;
 }
 
-.song-card-author {
-  font-size: 13px;
-  font-weight: 600;
-  opacity: 0.6;
+.song-card-meta {
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0.55;
+  margin-bottom: 10px;
 }
 
-.song-card-time {
-  font-size: 11px;
-  opacity: 0.4;
-  margin-bottom: 12px;
+/* Primary action row: play (fills) + copy-link icon */
+.song-card-actions {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  margin-top: auto;
 }
 
 .song-card-play {
-  display: block;
+  flex: 1;
   text-align: center;
   padding: 12px;
   border-radius: 14px;
@@ -148,7 +212,6 @@
   font-weight: 800;
   text-decoration: none;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
-  margin-top: auto;
 }
 
 .song-card-play:hover {
@@ -156,22 +219,19 @@
   box-shadow: 0 6px 16px rgba(0, 200, 83, 0.4);
 }
 
-/* Copy-share-link button (shown to everyone) */
-.song-card-share {
-  margin-top: 8px;
-  width: 100%;
-  padding: 8px;
-  border-radius: 12px;
+.song-card-copy {
+  flex-shrink: 0;
+  width: 48px;
+  border-radius: 14px;
   border: 1px solid var(--grid-line);
   background: var(--grid-bg);
   color: var(--foreground);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 18px;
   cursor: pointer;
   transition: background 0.15s ease;
 }
 
-.song-card-share:hover {
+.song-card-copy:hover {
   background: var(--grid-line);
 }
 
@@ -201,12 +261,6 @@
 }
 
 /* Owner controls on a song card */
-.song-card-owner {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
-}
-
 .song-card-mini {
   flex: 1;
   padding: 6px 8px;
@@ -244,18 +298,6 @@
 .song-card-mini:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* Template toggle (full-width, above rename/delete) */
-.song-card-mini.template {
-  width: 100%;
-  margin-top: 8px;
-}
-
-.song-card-mini.template.active {
-  background: linear-gradient(135deg, #f7971e, #ffd200);
-  color: white;
-  border-color: transparent;
 }
 
 /* Inline rename */

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -45,6 +45,7 @@ export type Translations = {
   playBtn: string;
   copyLink: string;
   linkCopied: string;
+  songMenu: string;
   feedAll: string;
   feedMine: string;
   feedTemplates: string;
@@ -106,6 +107,7 @@ export const translations: Record<Locale, Translations> = {
     playBtn: "Play",
     copyLink: "Copy link",
     linkCopied: "Copied!",
+    songMenu: "More",
     feedAll: "All",
     feedMine: "Mine",
     feedTemplates: "Templates",
@@ -164,6 +166,7 @@ export const translations: Record<Locale, Translations> = {
     playBtn: "あそぶ",
     copyLink: "リンクをコピー",
     linkCopied: "コピーしました！",
+    songMenu: "メニュー",
     feedAll: "みんな",
     feedMine: "じぶん",
     feedTemplates: "テンプレ",


### PR DESCRIPTION
## What

縦長になっていた曲カードを案A（⋯メニュー）で再デザイン。

- 作者名と日付を**1行**に集約
- 主要操作 = **あそぶ（伸長）＋ 🔗 リンクコピー アイコン**（全員）
- 所有者の管理操作（テンプレ/改名/削除）を art 上の **⋯ メニュー**に収納（所有者のみ・外側クリックで閉じる）。改名/削除の確認UIは従来のインライン表示を再利用
- メニューが切れないようカードを `overflow: visible`（art は上角丸を維持）

**非所有者（生徒）**は「タイトル → 作者・日付 → あそぶ＋🔗」の短いカードになります。

## Verification
- 匿名（非所有者）: コンパクトなカード、作者・日付が1行、⋯なし、🔗コピー有り、コンソールエラーなし（スクショ確認）
- `pnpm lint` / `tsc` / `build` グリーン、47テスト
- 所有者の ⋯ メニュー（テンプレ/改名/削除）はログイン時のみ表示のため、実機での確認をお願いします

## Before/After
- Before: タイトル/作者/日付/あそぶ/リンク/テンプレ/改名・削除 が縦に7段
- After: タイトル/作者・日付/(あそぶ＋🔗) ＋ 所有者は⋯メニュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)