### PR TITLE
feat: export the current song to WAV (#37)

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -15,6 +15,8 @@ interface Props {
   onUndo: () => void;
   onToggleSettings: () => void;
   onOpenSave: () => void;
+  onExport: () => void;
+  isExporting: boolean;
   onToggleLocale: () => void;
   user: User | null;
   onSignIn: () => void;
@@ -31,6 +33,8 @@ export function Header({
   onUndo,
   onToggleSettings,
   onOpenSave,
+  onExport,
+  isExporting,
   onToggleLocale,
   user,
   onSignIn,
@@ -71,6 +75,9 @@ export function Header({
       </button>
       <button className="save-btn" onClick={onOpenSave}>
         {t.save}
+      </button>
+      <button className="export-btn" onClick={onExport} disabled={isExporting}>
+        {isExporting ? t.exporting : t.exportWav}
       </button>
       <Link href="/songs" className="songs-nav-link">
         {t.songsLink}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
 import { migrateSong } from "@/core/legacy";
 import { buildRangeNotes, findMelodyNoteAt } from "@/ui/grid";
 import { AudioEngine } from "@/audio/engine";
+import { audioBufferToWavBlob } from "@/audio/wav";
 import { useDragInteraction } from "@/hooks/useDragInteraction";
 import { useLocale } from "@/hooks/useLocale";
 import { useSong } from "@/hooks/useSong";
@@ -42,6 +43,7 @@ export default function Home() {
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isLockMode, setIsLockMode] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   // The song loaded via ?load=<id>, so its owner can overwrite it on save.
   const [loadedSong, setLoadedSong] = useState<{
     id: string;
@@ -210,6 +212,28 @@ export default function Home() {
     setPlayheadStep(null);
   };
 
+  const handleExport = async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const buffer = await getEngine().renderOffline(songRef.current);
+      const blob = audioBufferToWavBlob(buffer);
+      const url = URL.createObjectURL(blob);
+      const base = (loadedSong?.title ?? "beatbubble").trim().replace(/[\\/:*?"<>|]/g, "_");
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${base || "beatbubble"}.wav`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Failed to export WAV:", error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const handleReset = () => {
     handleStop();
     reset();
@@ -280,6 +304,8 @@ export default function Home() {
         onUndo={undo}
         onToggleSettings={handleToggleSettings}
         onOpenSave={() => setIsSaveModalOpen(true)}
+        onExport={handleExport}
+        isExporting={isExporting}
         onToggleLocale={toggleLocale}
         user={user}
         onSignIn={signInWithGoogle}

--- a/src/app/styles/header.css
+++ b/src/app/styles/header.css
@@ -74,6 +74,11 @@
     order: 4;
   }
 
+  /* Same order as .save-btn; DOM order keeps export right after save. */
+  .export-btn {
+    order: 4;
+  }
+
   .songs-nav-link {
     order: 5;
   }
@@ -244,6 +249,30 @@
 .save-btn:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(17, 153, 142, 0.4);
+}
+
+/* Export (WAV download) button */
+.export-btn {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: none;
+  background: linear-gradient(135deg, #2193b0, #6dd5ed);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.export-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(33, 147, 176, 0.4);
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Locale toggle button (shared by editor header and songs page) */

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -3,8 +3,33 @@ import { noteNameToMidi, totalSteps } from "@/core/utils";
 
 export type TransportState = "stopped" | "playing";
 
+// A target for synthesis: any audio context (real-time or offline) plus the
+// master gain and noise buffer created on it. Parameterizing synthesis by the
+// target lets the exact same voices render both live (AudioContext) and offline
+// (OfflineAudioContext for WAV export), so exported audio matches playback.
+type RenderTarget = {
+  ctx: BaseAudioContext;
+  master: GainNode;
+  noiseBuffer: AudioBuffer;
+};
+
+// Seconds of silence/decay rendered after one loop so sustained notes and drum
+// tails ring out instead of being clipped at the loop boundary.
+const EXPORT_TAIL_SECONDS = 1.5;
+const EXPORT_SAMPLE_RATE = 44100;
+
 function midiToFreq(midi: number): number {
   return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+function createNoiseBuffer(ctx: BaseAudioContext): AudioBuffer {
+  const bufferSize = Math.floor(ctx.sampleRate * 0.5);
+  const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  return buffer;
 }
 
 export class AudioEngine {
@@ -32,23 +57,20 @@ export class AudioEngine {
       this.masterGain.connect(this.ctx.destination);
     }
     if (!this.noiseBuffer) {
-      this.noiseBuffer = this.createNoiseBuffer();
+      this.noiseBuffer = createNoiseBuffer(this.ctx);
     }
   }
 
-  private createNoiseBuffer(): AudioBuffer {
-    const bufferSize = this.ctx!.sampleRate * 0.5;
-    const buffer = this.ctx!.createBuffer(1, bufferSize, this.ctx!.sampleRate);
-    const data = buffer.getChannelData(0);
-    for (let i = 0; i < bufferSize; i++) {
-      data[i] = Math.random() * 2 - 1;
-    }
-    return buffer;
+  // The live (real-time) render target, or null if not initialized.
+  private liveTarget(): RenderTarget | null {
+    if (!this.ctx || !this.masterGain || !this.noiseBuffer) return null;
+    return { ctx: this.ctx, master: this.masterGain, noiseBuffer: this.noiseBuffer };
   }
 
   play(getSong: () => Song, onStep?: (step: number) => void): void {
     if (this.state === "playing") return;
-    if (!this.ctx || !this.masterGain) {
+    const target = this.liveTarget();
+    if (!target || !this.ctx) {
       console.error("AudioEngine not initialized. Call init() first.");
       return;
     }
@@ -68,7 +90,7 @@ export class AudioEngine {
       const currentSong = getSong();
 
       while (this.nextNoteTime < this.ctx.currentTime + this.LOOKAHEAD) {
-        this.scheduleStep(currentSong, this.currentStep, this.nextNoteTime, secondsPerStep);
+        this.scheduleStep(target, currentSong, this.currentStep, this.nextNoteTime, secondsPerStep);
 
         if (onStep) {
           const stepToReport = this.currentStep;
@@ -93,7 +115,37 @@ export class AudioEngine {
     scheduler();
   }
 
+  // Render one loop of the song (plus a short tail) offline and return the
+  // resulting AudioBuffer. Used for WAV export; does not touch live playback.
+  async renderOffline(song: Song): Promise<AudioBuffer> {
+    const secondsPerBeat = 60 / song.bpm;
+    const secondsPerStep = secondsPerBeat / song.stepsPerBeat;
+    const total = totalSteps(song);
+    const loopDuration = total * secondsPerStep;
+    const renderDuration = loopDuration + EXPORT_TAIL_SECONDS;
+
+    const length = Math.ceil(renderDuration * EXPORT_SAMPLE_RATE);
+    const offline = new OfflineAudioContext(1, length, EXPORT_SAMPLE_RATE);
+
+    const master = offline.createGain();
+    master.gain.value = 0.5;
+    master.connect(offline.destination);
+
+    const target: RenderTarget = {
+      ctx: offline,
+      master,
+      noiseBuffer: createNoiseBuffer(offline),
+    };
+
+    for (let step = 0; step < total; step++) {
+      this.scheduleStep(target, song, step, step * secondsPerStep, secondsPerStep);
+    }
+
+    return offline.startRendering();
+  }
+
   private scheduleStep(
+    target: RenderTarget,
     song: Song,
     step: number,
     time: number,
@@ -102,81 +154,88 @@ export class AudioEngine {
     for (const note of song.melody.notes) {
       if (note.startStep === step) {
         const duration = note.durationSteps * secondsPerStep;
-        this.playMelodyNote(note.note, time, duration, song.instrument);
+        this.playMelodyNote(target, note.note, time, duration, song.instrument);
       }
     }
 
     for (const hit of song.drums.hits) {
       if (hit.step === step) {
-        this.playDrum(hit.drumId, time);
+        this.playDrum(target, hit.drumId, time);
       }
     }
   }
 
   private playMelodyNote(
+    target: RenderTarget,
     noteName: string,
     startTime: number,
     duration: number,
     instrument: InstrumentId
   ): void {
-    if (!this.ctx || !this.masterGain) return;
-
     switch (instrument) {
       case "piano":
-        this.playPiano(noteName, startTime, duration);
+        this.playPiano(target, noteName, startTime, duration);
         break;
       case "synth":
-        this.playSynth(noteName, startTime, duration);
+        this.playSynth(target, noteName, startTime, duration);
         break;
       case "marimba":
-        this.playMarimba(noteName, startTime, duration);
+        this.playMarimba(target, noteName, startTime, duration);
         break;
       case "flute":
-        this.playFlute(noteName, startTime, duration);
+        this.playFlute(target, noteName, startTime, duration);
         break;
     }
   }
 
-  private playPiano(noteName: string, startTime: number, duration: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
+  private playPiano(
+    target: RenderTarget,
+    noteName: string,
+    startTime: number,
+    duration: number
+  ): void {
+    const { ctx, master } = target;
     const midi = noteNameToMidi(noteName);
     const freq = midiToFreq(midi);
 
-    const osc = this.ctx.createOscillator();
+    const osc = ctx.createOscillator();
     osc.type = "triangle";
     osc.frequency.value = freq;
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0, startTime);
     gain.gain.linearRampToValueAtTime(0.35, startTime + 0.005);
     gain.gain.setValueAtTime(0.35, startTime + duration - 0.03);
     gain.gain.linearRampToValueAtTime(0, startTime + duration);
 
     osc.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
 
     osc.start(startTime);
     osc.stop(startTime + duration + 0.01);
   }
 
-  private playSynth(noteName: string, startTime: number, duration: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
+  private playSynth(
+    target: RenderTarget,
+    noteName: string,
+    startTime: number,
+    duration: number
+  ): void {
+    const { ctx, master } = target;
     const midi = noteNameToMidi(noteName);
     const freq = midiToFreq(midi);
 
-    const osc = this.ctx.createOscillator();
+    const osc = ctx.createOscillator();
     osc.type = "sawtooth";
     osc.frequency.value = freq;
 
-    const filter = this.ctx.createBiquadFilter();
+    const filter = ctx.createBiquadFilter();
     filter.type = "lowpass";
     filter.frequency.setValueAtTime(2500, startTime);
     filter.frequency.exponentialRampToValueAtTime(900, startTime + 0.1);
     filter.Q.value = 3;
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0, startTime);
     gain.gain.linearRampToValueAtTime(0.25, startTime + 0.003);
     gain.gain.setValueAtTime(0.25, startTime + duration - 0.06);
@@ -184,43 +243,47 @@ export class AudioEngine {
 
     osc.connect(filter);
     filter.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
 
     osc.start(startTime);
     osc.stop(startTime + duration + 0.01);
   }
 
-  private playMarimba(noteName: string, startTime: number, duration: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
+  private playMarimba(
+    target: RenderTarget,
+    noteName: string,
+    startTime: number,
+    duration: number
+  ): void {
+    const { ctx, master } = target;
     const midi = noteNameToMidi(noteName);
     const freq = midiToFreq(midi);
 
     // Fundamental + 4th harmonic for marimba-like timbre
-    const osc1 = this.ctx.createOscillator();
+    const osc1 = ctx.createOscillator();
     osc1.type = "sine";
     osc1.frequency.value = freq;
 
-    const osc2 = this.ctx.createOscillator();
+    const osc2 = ctx.createOscillator();
     osc2.type = "sine";
     osc2.frequency.value = freq * 4;
 
     const decayTime = Math.min(duration, 0.6);
 
-    const gain1 = this.ctx.createGain();
+    const gain1 = ctx.createGain();
     gain1.gain.setValueAtTime(0, startTime);
     gain1.gain.linearRampToValueAtTime(0.45, startTime + 0.002);
     gain1.gain.exponentialRampToValueAtTime(0.001, startTime + decayTime);
 
-    const gain2 = this.ctx.createGain();
+    const gain2 = ctx.createGain();
     gain2.gain.setValueAtTime(0, startTime);
     gain2.gain.linearRampToValueAtTime(0.15, startTime + 0.002);
     gain2.gain.exponentialRampToValueAtTime(0.001, startTime + decayTime * 0.3);
 
     osc1.connect(gain1);
-    gain1.connect(this.masterGain);
+    gain1.connect(master);
     osc2.connect(gain2);
-    gain2.connect(this.masterGain);
+    gain2.connect(master);
 
     osc1.start(startTime);
     osc1.stop(startTime + decayTime + 0.01);
@@ -228,40 +291,44 @@ export class AudioEngine {
     osc2.stop(startTime + decayTime * 0.3 + 0.01);
   }
 
-  private playFlute(noteName: string, startTime: number, duration: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
+  private playFlute(
+    target: RenderTarget,
+    noteName: string,
+    startTime: number,
+    duration: number
+  ): void {
+    const { ctx, master } = target;
     const midi = noteNameToMidi(noteName);
     const freq = midiToFreq(midi);
 
-    const osc = this.ctx.createOscillator();
+    const osc = ctx.createOscillator();
     osc.type = "sine";
     osc.frequency.value = freq;
 
     // Faint 2nd harmonic for breath warmth
-    const osc2 = this.ctx.createOscillator();
+    const osc2 = ctx.createOscillator();
     osc2.type = "sine";
     osc2.frequency.value = freq * 2;
 
     const attack = Math.min(0.08, duration * 0.2);
     const release = Math.min(0.1, duration * 0.15);
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0, startTime);
     gain.gain.linearRampToValueAtTime(0.3, startTime + attack);
     gain.gain.setValueAtTime(0.3, startTime + duration - release);
     gain.gain.linearRampToValueAtTime(0, startTime + duration);
 
-    const gain2 = this.ctx.createGain();
+    const gain2 = ctx.createGain();
     gain2.gain.setValueAtTime(0, startTime);
     gain2.gain.linearRampToValueAtTime(0.06, startTime + attack);
     gain2.gain.setValueAtTime(0.06, startTime + duration - release);
     gain2.gain.linearRampToValueAtTime(0, startTime + duration);
 
     osc.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
     osc2.connect(gain2);
-    gain2.connect(this.masterGain);
+    gain2.connect(master);
 
     osc.start(startTime);
     osc.stop(startTime + duration + 0.01);
@@ -269,70 +336,66 @@ export class AudioEngine {
     osc2.stop(startTime + duration + 0.01);
   }
 
-  private playDrum(drumId: DrumId, time: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
+  private playDrum(target: RenderTarget, drumId: DrumId, time: number): void {
     switch (drumId) {
       case "kick":
-        this.playKick(time);
+        this.playKick(target, time);
         break;
       case "snare":
-        this.playSnare(time);
+        this.playSnare(target, time);
         break;
       case "hihat":
-        this.playHihat(time);
+        this.playHihat(target, time);
         break;
     }
   }
 
-  private playKick(time: number): void {
-    if (!this.ctx || !this.masterGain) return;
-
-    const osc = this.ctx.createOscillator();
+  private playKick(target: RenderTarget, time: number): void {
+    const { ctx, master } = target;
+    const osc = ctx.createOscillator();
     osc.type = "sine";
     osc.frequency.setValueAtTime(150, time);
     osc.frequency.exponentialRampToValueAtTime(40, time + 0.1);
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0.8, time);
     gain.gain.exponentialRampToValueAtTime(0.01, time + 0.3);
 
     osc.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
 
     osc.start(time);
     osc.stop(time + 0.3);
   }
 
-  private playSnare(time: number): void {
-    if (!this.ctx || !this.masterGain || !this.noiseBuffer) return;
+  private playSnare(target: RenderTarget, time: number): void {
+    const { ctx, master, noiseBuffer } = target;
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuffer;
 
-    const noise = this.ctx.createBufferSource();
-    noise.buffer = this.noiseBuffer;
-
-    const filter = this.ctx.createBiquadFilter();
+    const filter = ctx.createBiquadFilter();
     filter.type = "bandpass";
     filter.frequency.value = 3000;
     filter.Q.value = 1;
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0.5, time);
     gain.gain.exponentialRampToValueAtTime(0.01, time + 0.15);
 
-    const osc = this.ctx.createOscillator();
+    const osc = ctx.createOscillator();
     osc.type = "triangle";
     osc.frequency.value = 180;
 
-    const oscGain = this.ctx.createGain();
+    const oscGain = ctx.createGain();
     oscGain.gain.setValueAtTime(0.4, time);
     oscGain.gain.exponentialRampToValueAtTime(0.01, time + 0.05);
 
     noise.connect(filter);
     filter.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
 
     osc.connect(oscGain);
-    oscGain.connect(this.masterGain);
+    oscGain.connect(master);
 
     noise.start(time);
     noise.stop(time + 0.15);
@@ -340,23 +403,22 @@ export class AudioEngine {
     osc.stop(time + 0.05);
   }
 
-  private playHihat(time: number): void {
-    if (!this.ctx || !this.masterGain || !this.noiseBuffer) return;
+  private playHihat(target: RenderTarget, time: number): void {
+    const { ctx, master, noiseBuffer } = target;
+    const noise = ctx.createBufferSource();
+    noise.buffer = noiseBuffer;
 
-    const noise = this.ctx.createBufferSource();
-    noise.buffer = this.noiseBuffer;
-
-    const filter = this.ctx.createBiquadFilter();
+    const filter = ctx.createBiquadFilter();
     filter.type = "highpass";
     filter.frequency.value = 7000;
 
-    const gain = this.ctx.createGain();
+    const gain = ctx.createGain();
     gain.gain.setValueAtTime(0.2, time);
     gain.gain.exponentialRampToValueAtTime(0.01, time + 0.05);
 
     noise.connect(filter);
     filter.connect(gain);
-    gain.connect(this.masterGain);
+    gain.connect(master);
 
     noise.start(time);
     noise.stop(time + 0.05);
@@ -389,13 +451,15 @@ export class AudioEngine {
 
   async playNotePreview(noteName: string, instrument: InstrumentId): Promise<void> {
     await this.init();
-    if (!this.ctx) return;
-    this.playMelodyNote(noteName, this.ctx.currentTime, 0.3, instrument);
+    const target = this.liveTarget();
+    if (!target) return;
+    this.playMelodyNote(target, noteName, target.ctx.currentTime, 0.3, instrument);
   }
 
   async playDrumPreview(drumId: DrumId): Promise<void> {
     await this.init();
-    if (!this.ctx) return;
-    this.playDrum(drumId, this.ctx.currentTime);
+    const target = this.liveTarget();
+    if (!target) return;
+    this.playDrum(target, drumId, target.ctx.currentTime);
   }
 }

--- a/src/audio/wav.ts
+++ b/src/audio/wav.ts
@@ -1,0 +1,52 @@
+// Encode an AudioBuffer as a 16-bit PCM WAV (RIFF) Blob. No external library:
+// the format is small enough to hand-roll, and it keeps export dependency-free.
+// Channels are interleaved; samples are clamped to [-1, 1] before quantizing.
+export function audioBufferToWavBlob(buffer: AudioBuffer): Blob {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const numFrames = buffer.length;
+  const bytesPerSample = 2; // 16-bit
+  const blockAlign = numChannels * bytesPerSample;
+  const dataSize = numFrames * blockAlign;
+
+  const headerSize = 44;
+  const arrayBuffer = new ArrayBuffer(headerSize + dataSize);
+  const view = new DataView(arrayBuffer);
+
+  const writeString = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+  };
+
+  // RIFF header
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  // fmt chunk
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM chunk size
+  view.setUint16(20, 1, true); // audio format = PCM
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bytesPerSample * 8, true); // bits per sample
+  // data chunk
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  // Interleave channel data and write 16-bit signed samples.
+  const channels: Float32Array[] = [];
+  for (let ch = 0; ch < numChannels; ch++) channels.push(buffer.getChannelData(ch));
+
+  let offset = headerSize;
+  for (let frame = 0; frame < numFrames; frame++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      const sample = Math.max(-1, Math.min(1, channels[ch][frame]));
+      // Scale to int16 range with asymmetric bounds (-32768..32767).
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += 2;
+    }
+  }
+
+  return new Blob([arrayBuffer], { type: "audio/wav" });
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -20,6 +20,8 @@ export type Translations = {
   resetConfirm: string;
   confirmYes: string;
   save: string;
+  exportWav: string;
+  exporting: string;
   songsLink: string;
   // Note panel
   activeNotes: string;
@@ -85,6 +87,8 @@ export const translations: Record<Locale, Translations> = {
     resetConfirm: "Clear everything?",
     confirmYes: "Yes",
     save: "Save",
+    exportWav: "Export",
+    exporting: "Exporting...",
     songsLink: "Songs",
     activeNotes: "Active notes",
     tapToExclude: "Tap to exclude notes",
@@ -144,6 +148,8 @@ export const translations: Record<Locale, Translations> = {
     resetConfirm: "ぜんぶけす？",
     confirmYes: "はい",
     save: "ほぞん",
+    exportWav: "書き出し",
+    exporting: "書き出しちゅう...",
     songsLink: "みんなの曲",
     activeNotes: "つかうおと",
     tapToExclude: "のぞくおとをタップ",


### PR DESCRIPTION
## What

#37 phase A② — WAV書き出し。エディタに「書き出し」ボタンを追加し、編集中の曲を WAV ファイルとしてダウンロードできるようにしました。

- `OfflineAudioContext` で **1ループ＋1.5秒の余韻** をレンダリング（伸ばした音やドラムの余韻がループ境界で切れないように）
- 16-bit PCM・モノラルの WAV(RIFF) に手書きエンコード（外部ライブラリなし）
- Blob をアンカー経由でダウンロード。ファイル名は読み込み中の曲タイトル（未読込なら `beatbubble.wav`）

## How

`AudioEngine` の音色生成を `RenderTarget`（`ctx` + `master` + `noiseBuffer`）で引数化。これによりライブ再生（`AudioContext`）とオフライン書き出し（`OfflineAudioContext`）が**同じシンセ経路**を通り、書き出し音と再生音が一致します。`play()` のロジックとタイミング計算（`secondsPerStep`）はそのまま。

新規: `src/audio/wav.ts`（`audioBufferToWavBlob`）。

## Verify

- `pnpm lint` / `tsc --noEmit` / `vitest`（47 tests）すべてグリーン
- プレビューで実際の書き出し経路を実行し、生成 WAV を `decodeAudioData` で検証:
  - RIFF/WAVE/`fmt `/`data`、format=1(PCM)、16bit、mono、44100Hz
  - 長さ = 1ループ + 1.5s 余韻、ノート開始位置（step1 = 0.15s @bpm100）で発音、peak ≈ 0.17（非無音）
- ライブ再生の経路は未変更（ヘッドレス環境では autoplay 制約で `resume()` がジェスチャ待ちのため自動起動の確認は不可。要ブラウザ実機確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)