### PR TITLE
fix: 他人の非テンプレ曲でロックを操作できるようにする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,6 +50,7 @@ export default function Home() {
     title: string;
     author: string;
     userId: string | null;
+    isTemplate: boolean;
   } | null>(null);
 
   const gridRef = useRef<HTMLDivElement>(null);
@@ -69,7 +70,7 @@ export default function Home() {
     if (!loadId) return;
     supabase
       .from("songs")
-      .select("id, title, author, song_data, user_id")
+      .select("id, title, author, song_data, user_id, is_template")
       .eq("id", loadId)
       .single()
       .then(({ data }) => {
@@ -80,6 +81,7 @@ export default function Home() {
             title: data.title,
             author: data.author,
             userId: data.user_id ?? null,
+            isTemplate: data.is_template ?? false,
           });
           window.history.replaceState({}, "", "/");
         }
@@ -170,10 +172,12 @@ export default function Home() {
     [song, setSong, pushHistory]
   );
 
-  // Locks may only be edited by the song's author. Loading someone else's
-  // song (e.g. a template) makes the locks read-only, so a student can't
-  // unlock the fixed backing in their copy. A fresh, unsaved song is editable.
-  const canLock = !loadedSong || (!!user && loadedSong.userId === user.id);
+  // Lock editing is blocked only for someone else's *template*: a student must
+  // not be able to unlock the fixed backing in a template they opened. Any other
+  // song — fresh, your own, or someone else's non-template — stays freely
+  // lockable (overwriting the saved row is still owner-only, enforced by RLS).
+  const isLoadedOwner = !!user && !!loadedSong && loadedSong.userId === user.id;
+  const canLock = !loadedSong || isLoadedOwner || !loadedSong.isTemplate;
   const lockActive = isLockMode && canLock;
 
   const { isDragging, getMelodyCellHandlers, getDrumCellHandlers, containerHandlers } =


### PR DESCRIPTION
## バグ
他人の曲を読み込むと、テンプレかどうかに関係なく**ロックモードのトグルが非表示**になっていた。本来ハードロックは**テンプレ曲のみ**を対象とすべき（生徒がテンプレの固定パートを解除できないように）。それ以外の曲（新規・自分の曲・他人の非テンプレ曲）はロックを自由に操作できるべき（上書き保存だけは本人のみ＝RLSで担保）。

## 修正
- 読み込みクエリに `is_template` を追加し、`loadedSong` に保持
- `canLock` を「**非オーナーのテンプレ曲のときだけ false**」に変更

| 曲 | ロック操作 | 上書き保存 |
|---|---|---|
| 新規 | ✅ | （新規作成） |
| 自分の曲 | ✅ | ✅ 本人のみ |
| 他人の非テンプレ曲 | ✅（←修正） | ❌ |
| 他人のテンプレ曲 | ❌ ハードロック | ❌ |

## 検証
- `pnpm lint` / `tsc` / `vitest`（47 tests）グリーン
- プレビューで匿名ユーザー（＝非オーナー）が他人の**非テンプレ曲**を読み込み → 設定に「🔒 ロック」が表示され、ロックモードが有効化されることを確認（修正前は非表示）
- テンプレ曲のハードロック側はロジック上不変（現在DBにテンプレ曲が無いためライブ確認は非テンプレ側のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)