### PR TITLE
fix(audio): 再生中にPianoへ切り替えても8bit音のままになるバグ

### DIFF
--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -270,16 +270,14 @@ export class AudioEngine {
     // permanently uncancellable.
     const epoch = ++this.playEpoch;
 
-    // The render target snapshots pianoReady, so a loop started before the
-    // samples finished loading would stay on the fallback voice for the whole
-    // loop — wait for the piano first (bounded).
+    // When the song starts on the piano, wait for its samples first (bounded)
+    // so the opening notes don't come out as the 8bit fallback.
     if (usesSampledPiano(getSong())) {
       await this.waitForPianoReady(PIANO_WAIT_PLAY_MS);
       if (this.state !== "playing" || epoch !== this.playEpoch) return;
     }
 
-    const target = this.liveTarget();
-    if (!target || !this.ctx) {
+    if (!this.liveTarget()) {
       this.state = "stopped";
       return;
     }
@@ -293,16 +291,22 @@ export class AudioEngine {
     const total = totalSteps(initialSong);
 
     const scheduler = () => {
-      if (!this.ctx || this.state !== "playing") return;
+      if (this.state !== "playing") return;
+      // Re-resolve the target every tick instead of snapshotting it once:
+      // target.piano reflects pianoReady at resolve time, so a snapshot taken
+      // before the samples finished loading would pin the whole loop to the
+      // 8bit fallback — audible when switching a playing song to the piano.
+      const target = this.liveTarget();
+      if (!target) return;
 
       const currentSong = getSong();
 
-      while (this.nextNoteTime < this.ctx.currentTime + this.LOOKAHEAD) {
+      while (this.nextNoteTime < target.ctx.currentTime + this.LOOKAHEAD) {
         this.scheduleStep(target, currentSong, this.currentStep, this.nextNoteTime, secondsPerStep);
 
         if (onStep) {
           const stepToReport = this.currentStep;
-          const timeUntilStep = (this.nextNoteTime - this.ctx.currentTime) * 1000;
+          const timeUntilStep = (this.nextNoteTime - target.ctx.currentTime) * 1000;
           setTimeout(() => {
             if (this.state === "playing") {
               onStep(stepToReport);


### PR DESCRIPTION
## バグ

ピアノ以外の楽器で保存された曲を再生し、**再生中に**Pianoへ切り替えると8bitの音のまま。他の楽器への切替は即反映される。停止→再度えんそうでピアノ音になる。

## 原因

`play()` がレンダーターゲットを再生開始時に1回だけスナップショットしており、`target.piano` は「その瞬間サンプルがロード済みか」で固定される。ピアノ以外の曲はロード完了を待たずに再生を始めるため、スナップショットは `piano = null` になりがちで、以後ループ全体が8bitフォールバックに固定されていた（停止→再生で新しいスナップショットを取ると直る＝報告どおりの症状）。

## 修正

スケジューラのtick毎（25ms）にターゲットを再解決する。曲データが毎tick `getSong()` で読み直されて他の楽器が即反映されるのと同じ構造に統一。

## 検証

- サンプルロードに人工5秒遅延を入れて再現テスト：Synthで再生→2秒後にPianoへ切替→ロード中は8bitフォールバック→**完了と同時に停止なしでサンプルピアノへ切替**することをログで確認（旧コードは停止まで永久に8bit）
- 検証用一時コードは除去済み
- 型 / lint / vitest 57件 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)