### PR TITLE
feat(db): songs.updated_at（上書き保存で更新、サーバー側制御）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Playful, rounded, kid-friendly. Keep new UI consistent with these:
 - Both `/` and `/songs` pages share the account menu (locale switch works signed out too)
 
 ## Save / Feed
-- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at)
+- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at, updated_at)
+  - `updated_at` is server-controlled (trigger): bumped only when title/author/song_data change (overwrite-save, rename) — not by hidden/is_template flips
 - Public read + insert RLS policies (no auth required)
 - `/songs` page lists the 50 most recent songs; each card links to `/?load=<id>`
 - Editor loads a song via `?load=<id>` on mount **through `migrateSong()`**, then cleans the URL with `replaceState`

--- a/supabase/migrations/0005_songs_updated_at.sql
+++ b/supabase/migrations/0005_songs_updated_at.sql
@@ -1,0 +1,31 @@
+-- updated_at for songs: bumped when the song content (song_data / title /
+-- author) changes — i.e. an overwrite-save or rename. Moderation/metadata
+-- flags (hidden, is_template) do not count as edits.
+--
+-- Server-controlled: the trigger first restores the old value, so a client
+-- can neither spoof updated_at directly nor forget to set it.
+
+alter table public.songs
+  add column if not exists updated_at timestamptz not null default now();
+
+-- Existing rows: treat creation as the last update.
+update public.songs set updated_at = coalesce(created_at, now());
+
+create or replace function public.songs_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := old.updated_at;
+  if (new.title, new.author, new.song_data)
+     is distinct from (old.title, old.author, old.song_data) then
+    new.updated_at := now();
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists songs_touch_updated_at on public.songs;
+create trigger songs_touch_updated_at
+  before update on public.songs
+  for each row execute function public.songs_touch_updated_at();


### PR DESCRIPTION
## 概要

`songs` テーブルに `updated_at` を追加。上書き保存した際に更新されるようにします。

## 設計

**BEFORE UPDATE トリガーによるサーバー側制御**（クライアントからの送り忘れ・改ざんが構造的に不可能）:

- `title / author / song_data` が実際に変わったときだけ `now()` にbump
  - **上書き保存・名前変更 = 更新扱い**
  - `hidden` / `is_template` の切替（モデレーション・メタデータ）= 更新扱いしない
- クライアントが `updated_at` を直接送っても無視（トリガーがまず旧値に戻してから判定）
- 既存行は `created_at` でバックフィル

クライアント側の変更は不要（SaveModal の上書き `.update()` がそのままトリガーを発火）。

## 検証

- [x] マイグレーション適用済み（本番 BeatBubble プロジェクト）
- [x] 実データで検証（トランザクション内・ロールバック済み）:
  - コンテンツ変更 → bump ✓
  - テンプレ切替のみ → bumpしない ✓
  - `updated_at` 直接書き換え → 無視 ✓
- [x] CLAUDE.md のスキーマ記述を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)