### PR TITLE
fix(songs): みんなのきょくの時刻を updated_at で表示・並び替え

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Playful, rounded, kid-friendly. Keep new UI consistent with these:
 - Both `/` and `/songs` pages share the account menu (locale switch works signed out too)
 
 ## Save / Feed
-- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at)
+- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at, updated_at)
+  - `updated_at` is server-controlled (trigger): bumped only when title/author/song_data change (overwrite-save, rename) — not by hidden/is_template flips
 - Public read + insert RLS policies (no auth required)
 - `/songs` page lists the 50 most recent songs; each card links to `/?load=<id>`
 - Editor loads a song via `?load=<id>` on mount **through `migrateSong()`**, then cleans the URL with `replaceState`

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -18,6 +18,7 @@ type FeedSong = {
   title: string;
   author: string;
   created_at: string;
+  updated_at: string;
   song_data: Song;
   user_id: string | null;
   is_template: boolean;
@@ -69,12 +70,12 @@ export default function SongsPage() {
   useEffect(() => {
     let query = supabase
       .from("songs")
-      .select("id, title, author, created_at, song_data, user_id, is_template");
+      .select("id, title, author, created_at, updated_at, song_data, user_id, is_template");
     if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
     else if (effectiveView === "templates") query = query.eq("is_template", true);
     else query = query.eq("is_template", false); // "all" excludes templates
     query
-      .order("created_at", { ascending: false })
+      .order("updated_at", { ascending: false })
       .limit(50)
       .then(({ data }) => {
         setSongs((data as FeedSong[]) ?? []);
@@ -173,7 +174,7 @@ export default function SongsPage() {
                 id={song.id}
                 title={song.title}
                 author={song.author}
-                time={timeAgo(song.created_at, locale)}
+                time={timeAgo(song.updated_at, locale)}
                 gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
                 isOwner={!!user && song.user_id === user.id}
                 isTemplate={song.is_template}

--- a/supabase/migrations/0005_songs_updated_at.sql
+++ b/supabase/migrations/0005_songs_updated_at.sql
@@ -1,0 +1,31 @@
+-- updated_at for songs: bumped when the song content (song_data / title /
+-- author) changes — i.e. an overwrite-save or rename. Moderation/metadata
+-- flags (hidden, is_template) do not count as edits.
+--
+-- Server-controlled: the trigger first restores the old value, so a client
+-- can neither spoof updated_at directly nor forget to set it.
+
+alter table public.songs
+  add column if not exists updated_at timestamptz not null default now();
+
+-- Existing rows: treat creation as the last update.
+update public.songs set updated_at = coalesce(created_at, now());
+
+create or replace function public.songs_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := old.updated_at;
+  if (new.title, new.author, new.song_data)
+     is distinct from (old.title, old.author, old.song_data) then
+    new.updated_at := now();
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists songs_touch_updated_at on public.songs;
+create trigger songs_touch_updated_at
+  before update on public.songs
+  for each row execute function public.songs_touch_updated_at();


### PR DESCRIPTION
## 変更

`/songs`（みんなのきょく）のカードの相対時刻「○時間まえ」を、`created_at` ではなく **`updated_at`** で表示するように変更。

- 表示：`timeAgo(song.updated_at, …)`
- **並び順も `updated_at` 降順に変更**：表示だけ updated にすると、編集した曲が「1分まえ」でも古い「1時間まえ」の下に来て不整合になるため。両方 updated_at で揃え、表示時刻が常に単調降順になるようにした
- 型定義・select に `updated_at` を追加

## タイムゾーン

問題なし（相対表示のためTZ非依存）：
- 保存は `timestamptz` + `now()` = 絶対的な瞬間として記録
- クライアントが受け取る文字列はオフセット付きISO（`…+00:00`）で、`Date.now() - new Date(...)` の経過時間計算は端末TZに依存しない

## 検証

- [x] 型 / lint / vitest 57件
- [x] `/songs` を実表示：相対時刻が単調降順（1時間→2時間→14時間）で整合
- 既存曲は updated==created（バックフィル済み）なので現状の見た目は不変。今後、上書き保存・名前変更した曲が「たったいま」で先頭に来る

前提：#63（songs.updated_at 追加）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)