### PR TITLE
fix(songs): 全曲表示できるようにページング＋フィードUIモダン化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Playful, rounded, kid-friendly. Keep new UI consistent with these:
 - Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at, updated_at)
   - `updated_at` is server-controlled (trigger): bumped only when title/author/song_data change (overwrite-save, rename) — not by hidden/is_template flips
 - Public read + insert RLS policies (no auth required)
-- `/songs` page lists the 50 most recent songs; each card links to `/?load=<id>`
+- `/songs` page paginates all songs newest-first (24/page via `.range()`, infinite scroll + "もっと見る" fallback); each card links to `/?load=<id>`
 - Editor loads a song via `?load=<id>` on mount **through `migrateSong()`**, then cleans the URL with `replaceState`
 - Required env vars: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
@@ -25,6 +25,11 @@ type FeedSong = {
 };
 
 type View = "all" | "mine" | "templates";
+
+// How many songs to fetch per page. The feed loads more as you scroll.
+const PAGE_SIZE = 24;
+
+const SONG_COLUMNS = "id, title, author, created_at, updated_at, song_data, user_id, is_template";
 
 const CARD_GRADIENTS = [
   "linear-gradient(135deg, #ff6b6b, #feca57)",
@@ -52,8 +57,16 @@ export default function SongsPage() {
   const { profile, saveProfile } = useProfile(user);
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [total, setTotal] = useState<number | null>(null);
   const [view, setView] = useState<View>("all");
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const pageRef = useRef(0);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Ref (not state) so overlapping triggers — the scroll observer and the
+  // button firing together — can't start two fetches for the same page.
+  const loadingMoreRef = useRef(false);
 
   // Identity line for the account menu, from whatever profile fields are set.
   const profileSubtitle = [
@@ -67,21 +80,77 @@ export default function SongsPage() {
   // "mine" needs sign-in; "all" and "templates" are open to everyone.
   const effectiveView: View = !user && view === "mine" ? "all" : view;
 
+  // One page of the current view, ordered newest-first. `count: "exact"` on
+  // every request keeps the total in sync as songs are added/removed.
+  const fetchPage = useCallback(
+    (from: number) => {
+      let query = supabase.from("songs").select(SONG_COLUMNS, { count: "exact" });
+      if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
+      else if (effectiveView === "templates") query = query.eq("is_template", true);
+      else query = query.eq("is_template", false); // "all" excludes templates
+      return query.order("updated_at", { ascending: false }).range(from, from + PAGE_SIZE - 1);
+    },
+    [effectiveView, user]
+  );
+
+  // Initial load, and reset whenever the view (or sign-in state) changes.
   useEffect(() => {
-    let query = supabase
-      .from("songs")
-      .select("id, title, author, created_at, updated_at, song_data, user_id, is_template");
-    if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
-    else if (effectiveView === "templates") query = query.eq("is_template", true);
-    else query = query.eq("is_template", false); // "all" excludes templates
-    query
-      .order("updated_at", { ascending: false })
-      .limit(50)
-      .then(({ data }) => {
-        setSongs((data as FeedSong[]) ?? []);
-        setLoading(false);
+    let active = true;
+    async function loadFirstPage() {
+      setLoading(true);
+      setSongs([]);
+      setHasMore(false);
+      pageRef.current = 0;
+      loadingMoreRef.current = false;
+      const { data, count } = await fetchPage(0);
+      if (!active) return;
+      const rows = (data as FeedSong[]) ?? [];
+      setSongs(rows);
+      setTotal(count ?? rows.length);
+      setHasMore(rows.length === PAGE_SIZE);
+      setLoading(false);
+    }
+    loadFirstPage();
+    return () => {
+      active = false;
+    };
+  }, [fetchPage]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    const nextPage = pageRef.current + 1;
+    try {
+      const { data, count } = await fetchPage(nextPage * PAGE_SIZE);
+      const rows = (data as FeedSong[]) ?? [];
+      pageRef.current = nextPage;
+      // De-dupe by id in case a song was inserted between page fetches.
+      setSongs((prev) => {
+        const seen = new Set(prev.map((s) => s.id));
+        return [...prev, ...rows.filter((r) => !seen.has(r.id))];
       });
-  }, [effectiveView, user]);
+      if (count != null) setTotal(count);
+      setHasMore(rows.length === PAGE_SIZE);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [fetchPage, hasMore]);
+
+  // Infinite scroll: pull the next page as the sentinel nears the viewport.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: "600px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   // Client-side filter keeps the view correct instantly while a refetch lands.
   const displayed =
@@ -133,31 +202,47 @@ export default function SongsPage() {
       )}
 
       <main className="songs-main">
-        <div className="songs-tabs">
-          <button
-            className={`songs-tab ${effectiveView === "all" ? "active" : ""}`}
-            onClick={() => setView("all")}
-          >
-            {t.feedAll}
-          </button>
-          <button
-            className={`songs-tab ${effectiveView === "templates" ? "active" : ""}`}
-            onClick={() => setView("templates")}
-          >
-            {t.feedTemplates}
-          </button>
-          {user && (
+        <div className="songs-toolbar">
+          <div className="songs-tabs">
             <button
-              className={`songs-tab ${effectiveView === "mine" ? "active" : ""}`}
-              onClick={() => setView("mine")}
+              className={`songs-tab ${effectiveView === "all" ? "active" : ""}`}
+              onClick={() => setView("all")}
             >
-              {t.feedMine}
+              {t.feedAll}
             </button>
+            <button
+              className={`songs-tab ${effectiveView === "templates" ? "active" : ""}`}
+              onClick={() => setView("templates")}
+            >
+              {t.feedTemplates}
+            </button>
+            {user && (
+              <button
+                className={`songs-tab ${effectiveView === "mine" ? "active" : ""}`}
+                onClick={() => setView("mine")}
+              >
+                {t.feedMine}
+              </button>
+            )}
+          </div>
+          {!loading && total != null && displayed.length > 0 && (
+            <span className="songs-count">{t.songsCount(total)}</span>
           )}
         </div>
 
         {loading ? (
-          <p className="songs-status">{t.loading}</p>
+          <div className="songs-grid" aria-busy="true">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="song-card-skeleton" aria-hidden="true">
+                <div className="song-card-skeleton-art" />
+                <div className="song-card-skeleton-body">
+                  <div className="song-card-skeleton-line wide" />
+                  <div className="song-card-skeleton-line" />
+                  <div className="song-card-skeleton-btn" />
+                </div>
+              </div>
+            ))}
+          </div>
         ) : displayed.length === 0 ? (
           <p className="songs-status">
             {effectiveView === "mine"
@@ -167,24 +252,39 @@ export default function SongsPage() {
                 : t.noSongs}
           </p>
         ) : (
-          <div className="songs-grid">
-            {displayed.map((song, i) => (
-              <SongCard
-                key={song.id}
-                id={song.id}
-                title={song.title}
-                author={song.author}
-                time={timeAgo(song.updated_at, locale)}
-                gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
-                isOwner={!!user && song.user_id === user.id}
-                isTemplate={song.is_template}
-                t={t}
-                onDeleted={handleDeleted}
-                onRenamed={handleRenamed}
-                onTemplateToggled={handleTemplateToggled}
-              />
-            ))}
-          </div>
+          <>
+            <div className="songs-grid">
+              {displayed.map((song, i) => (
+                <SongCard
+                  key={song.id}
+                  id={song.id}
+                  title={song.title}
+                  author={song.author}
+                  time={timeAgo(song.updated_at, locale)}
+                  gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
+                  isOwner={!!user && song.user_id === user.id}
+                  isTemplate={song.is_template}
+                  t={t}
+                  onDeleted={handleDeleted}
+                  onRenamed={handleRenamed}
+                  onTemplateToggled={handleTemplateToggled}
+                />
+              ))}
+            </div>
+            {hasMore && <div ref={sentinelRef} className="songs-sentinel" aria-hidden="true" />}
+            {hasMore &&
+              (loadingMore ? (
+                <p className="songs-more-status">{t.loadingMore}</p>
+              ) : (
+                // Auto-loads on scroll via the observer; this button is a
+                // reliable fallback for environments where it doesn't fire.
+                <div className="songs-more-wrap">
+                  <button className="songs-more-btn" onClick={loadMore}>
+                    {t.showMore}
+                  </button>
+                </div>
+              ))}
+          </>
         )}
       </main>
     </div>

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,35 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
-import { supabase } from "@/lib/supabase";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
+import { useSongFeed, type FeedView } from "@/hooks/useSongFeed";
 import { AccountMenu } from "@/app/components/AccountMenu";
 import { ProfileModal } from "@/app/components/ProfileModal";
 import { SongCard } from "@/app/components/SongCard";
-import type { Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
-
-type FeedSong = {
-  id: string;
-  title: string;
-  author: string;
-  created_at: string;
-  updated_at: string;
-  song_data: Song;
-  user_id: string | null;
-  is_template: boolean;
-};
-
-type View = "all" | "mine" | "templates";
-
-// How many songs to fetch per page. The feed loads more as you scroll.
-const PAGE_SIZE = 24;
-
-const SONG_COLUMNS = "id, title, author, created_at, updated_at, song_data, user_id, is_template";
 
 const CARD_GRADIENTS = [
   "linear-gradient(135deg, #ff6b6b, #feca57)",
@@ -55,18 +36,24 @@ export default function SongsPage() {
   const { locale, t, changeLocale } = useLocale();
   const { user, signInWithGoogle, signOut } = useAuth();
   const { profile, saveProfile } = useProfile(user);
-  const [songs, setSongs] = useState<FeedSong[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [total, setTotal] = useState<number | null>(null);
-  const [view, setView] = useState<View>("all");
+  const [view, setView] = useState<FeedView>("all");
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
-  const pageRef = useRef(0);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  // Ref (not state) so overlapping triggers — the scroll observer and the
-  // button firing together — can't start two fetches for the same page.
-  const loadingMoreRef = useRef(false);
+
+  // "mine" needs sign-in; "all" and "templates" are open to everyone.
+  const effectiveView: FeedView = !user && view === "mine" ? "all" : view;
+
+  const {
+    songs,
+    total,
+    loading,
+    loadingMore,
+    hasMore,
+    loadMore,
+    sentinelRef,
+    removeSong,
+    renameSong,
+    setSongTemplate,
+  } = useSongFeed(effectiveView, user);
 
   // Identity line for the account menu, from whatever profile fields are set.
   const profileSubtitle = [
@@ -76,101 +63,6 @@ export default function SongsPage() {
   ]
     .filter(Boolean)
     .join("・");
-
-  // "mine" needs sign-in; "all" and "templates" are open to everyone.
-  const effectiveView: View = !user && view === "mine" ? "all" : view;
-
-  // One page of the current view, ordered newest-first. `count: "exact"` on
-  // every request keeps the total in sync as songs are added/removed.
-  const fetchPage = useCallback(
-    (from: number) => {
-      let query = supabase.from("songs").select(SONG_COLUMNS, { count: "exact" });
-      if (effectiveView === "mine" && user) query = query.eq("user_id", user.id);
-      else if (effectiveView === "templates") query = query.eq("is_template", true);
-      else query = query.eq("is_template", false); // "all" excludes templates
-      return query.order("updated_at", { ascending: false }).range(from, from + PAGE_SIZE - 1);
-    },
-    [effectiveView, user]
-  );
-
-  // Initial load, and reset whenever the view (or sign-in state) changes.
-  useEffect(() => {
-    let active = true;
-    async function loadFirstPage() {
-      setLoading(true);
-      setSongs([]);
-      setHasMore(false);
-      pageRef.current = 0;
-      loadingMoreRef.current = false;
-      const { data, count } = await fetchPage(0);
-      if (!active) return;
-      const rows = (data as FeedSong[]) ?? [];
-      setSongs(rows);
-      setTotal(count ?? rows.length);
-      setHasMore(rows.length === PAGE_SIZE);
-      setLoading(false);
-    }
-    loadFirstPage();
-    return () => {
-      active = false;
-    };
-  }, [fetchPage]);
-
-  const loadMore = useCallback(async () => {
-    if (loadingMoreRef.current || !hasMore) return;
-    loadingMoreRef.current = true;
-    setLoadingMore(true);
-    const nextPage = pageRef.current + 1;
-    try {
-      const { data, count } = await fetchPage(nextPage * PAGE_SIZE);
-      const rows = (data as FeedSong[]) ?? [];
-      pageRef.current = nextPage;
-      // De-dupe by id in case a song was inserted between page fetches.
-      setSongs((prev) => {
-        const seen = new Set(prev.map((s) => s.id));
-        return [...prev, ...rows.filter((r) => !seen.has(r.id))];
-      });
-      if (count != null) setTotal(count);
-      setHasMore(rows.length === PAGE_SIZE);
-    } finally {
-      loadingMoreRef.current = false;
-      setLoadingMore(false);
-    }
-  }, [fetchPage, hasMore]);
-
-  // Infinite scroll: pull the next page as the sentinel nears the viewport.
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) loadMore();
-      },
-      { rootMargin: "600px" }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [loadMore]);
-
-  // Client-side filter keeps the view correct instantly while a refetch lands.
-  const displayed =
-    effectiveView === "mine" && user
-      ? songs.filter((s) => s.user_id === user.id)
-      : effectiveView === "templates"
-        ? songs.filter((s) => s.is_template)
-        : songs.filter((s) => !s.is_template);
-
-  const handleDeleted = useCallback((id: string) => {
-    setSongs((prev) => prev.filter((s) => s.id !== id));
-  }, []);
-
-  const handleRenamed = useCallback((id: string, title: string) => {
-    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, title } : s)));
-  }, []);
-
-  const handleTemplateToggled = useCallback((id: string, isTemplate: boolean) => {
-    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, is_template: isTemplate } : s)));
-  }, []);
 
   return (
     <div className="songs-page">
@@ -225,7 +117,7 @@ export default function SongsPage() {
               </button>
             )}
           </div>
-          {!loading && total != null && displayed.length > 0 && (
+          {!loading && total != null && songs.length > 0 && (
             <span className="songs-count">{t.songsCount(total)}</span>
           )}
         </div>
@@ -243,7 +135,7 @@ export default function SongsPage() {
               </div>
             ))}
           </div>
-        ) : displayed.length === 0 ? (
+        ) : songs.length === 0 ? (
           <p className="songs-status">
             {effectiveView === "mine"
               ? t.noMySongs
@@ -254,7 +146,7 @@ export default function SongsPage() {
         ) : (
           <>
             <div className="songs-grid">
-              {displayed.map((song, i) => (
+              {songs.map((song, i) => (
                 <SongCard
                   key={song.id}
                   id={song.id}
@@ -265,9 +157,9 @@ export default function SongsPage() {
                   isOwner={!!user && song.user_id === user.id}
                   isTemplate={song.is_template}
                   t={t}
-                  onDeleted={handleDeleted}
-                  onRenamed={handleRenamed}
-                  onTemplateToggled={handleTemplateToggled}
+                  onDeleted={removeSong}
+                  onRenamed={renameSong}
+                  onTemplateToggled={setSongTemplate}
                 />
               ))}
             </div>

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -235,11 +235,27 @@
   background: var(--grid-line);
 }
 
+/* Toolbar: filter tabs on the left, song count on the right */
+.songs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.songs-count {
+  font-size: 14px;
+  font-weight: 700;
+  opacity: 0.5;
+  white-space: nowrap;
+}
+
 /* My/All filter tabs */
 .songs-tabs {
   display: flex;
   gap: 8px;
-  margin-bottom: 20px;
 }
 
 .songs-tab {
@@ -372,4 +388,108 @@
 
 .songs-header .account-menu {
   margin-left: auto;
+}
+
+/* Infinite scroll: sentinel is an invisible tripwire near the list end */
+.songs-sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+.songs-more-status {
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  opacity: 0.5;
+  padding: 24px 0 8px;
+}
+
+.songs-more-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0 8px;
+}
+
+.songs-more-btn {
+  padding: 10px 28px;
+  border-radius: 20px;
+  border: 1.5px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.songs-more-btn:hover {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-color: transparent;
+  color: white;
+}
+
+/* Skeleton placeholders shown while a page loads */
+.song-card-skeleton {
+  background: var(--grid-bg);
+  border-radius: 20px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.song-card-skeleton-art {
+  height: 90px;
+}
+
+.song-card-skeleton-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.song-card-skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  width: 60%;
+}
+
+.song-card-skeleton-line.wide {
+  width: 85%;
+}
+
+.song-card-skeleton-btn {
+  height: 40px;
+  border-radius: 14px;
+  margin-top: 6px;
+}
+
+/* Shimmer sweep across every skeleton surface */
+.song-card-skeleton-art,
+.song-card-skeleton-line,
+.song-card-skeleton-btn {
+  background: linear-gradient(
+    100deg,
+    var(--grid-line) 30%,
+    var(--header-bg) 50%,
+    var(--grid-line) 70%
+  );
+  background-size: 200% 100%;
+  animation: song-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes song-skeleton-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .song-card-skeleton-art,
+  .song-card-skeleton-line,
+  .song-card-skeleton-btn {
+    animation: none;
+  }
 }

--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { User } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+import type { Song } from "@/core/types";
+
+export type FeedView = "all" | "mine" | "templates";
+
+export type FeedSong = {
+  id: string;
+  title: string;
+  author: string;
+  created_at: string;
+  updated_at: string;
+  song_data: Song;
+  user_id: string | null;
+  is_template: boolean;
+};
+
+// How many songs to fetch per page. The feed loads more as you scroll.
+const PAGE_SIZE = 24;
+
+const SONG_COLUMNS = "id, title, author, created_at, updated_at, song_data, user_id, is_template";
+
+// Whether a song belongs to a view — mirrors the server-side filter, so a
+// locally-mutated song (template toggled, etc.) leaves/stays in the list
+// immediately without waiting for a refetch.
+function matchesView(song: FeedSong, view: FeedView, user: User | null): boolean {
+  if (view === "mine") return !!user && song.user_id === user.id;
+  if (view === "templates") return song.is_template;
+  return !song.is_template; // "all" excludes templates
+}
+
+// Paginated songs feed for a view. Owns fetching, infinite scroll, and the
+// local mutations that keep the list in sync after a card edits itself.
+// Attach `sentinelRef` to an element near the list end for scroll auto-load;
+// call `loadMore()` from a button as a fallback where the observer can't fire.
+export function useSongFeed(view: FeedView, user: User | null) {
+  const [songs, setSongs] = useState<FeedSong[]>([]);
+  const [total, setTotal] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const pageRef = useRef(0);
+  // Ref (not state) so overlapping triggers — the scroll observer and the
+  // button firing together — can't start two fetches for the same page.
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // One page of the current view, newest-first. `count: "exact"` keeps the
+  // total in sync as songs are added/removed.
+  const fetchPage = useCallback(
+    (from: number) => {
+      let query = supabase.from("songs").select(SONG_COLUMNS, { count: "exact" });
+      if (view === "mine" && user) query = query.eq("user_id", user.id);
+      else if (view === "templates") query = query.eq("is_template", true);
+      else query = query.eq("is_template", false);
+      return query.order("updated_at", { ascending: false }).range(from, from + PAGE_SIZE - 1);
+    },
+    [view, user]
+  );
+
+  // Initial load, and reset whenever the view (or sign-in state) changes.
+  useEffect(() => {
+    let active = true;
+    async function loadFirstPage() {
+      setLoading(true);
+      setSongs([]);
+      setHasMore(false);
+      pageRef.current = 0;
+      loadingMoreRef.current = false;
+      const { data, count } = await fetchPage(0);
+      if (!active) return;
+      const rows = (data as FeedSong[]) ?? [];
+      setSongs(rows);
+      setTotal(count ?? rows.length);
+      setHasMore(rows.length === PAGE_SIZE);
+      setLoading(false);
+    }
+    loadFirstPage();
+    return () => {
+      active = false;
+    };
+  }, [fetchPage]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMoreRef.current || !hasMore) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    const nextPage = pageRef.current + 1;
+    try {
+      const { data, count } = await fetchPage(nextPage * PAGE_SIZE);
+      const rows = (data as FeedSong[]) ?? [];
+      pageRef.current = nextPage;
+      // De-dupe by id in case a song was inserted between page fetches.
+      setSongs((prev) => {
+        const seen = new Set(prev.map((s) => s.id));
+        return [...prev, ...rows.filter((r) => !seen.has(r.id))];
+      });
+      if (count != null) setTotal(count);
+      setHasMore(rows.length === PAGE_SIZE);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [fetchPage, hasMore]);
+
+  // Infinite scroll: pull the next page as the sentinel nears the viewport.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: "600px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  const removeSong = useCallback((id: string) => {
+    setSongs((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const renameSong = useCallback((id: string, title: string) => {
+    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, title } : s)));
+  }, []);
+
+  const setSongTemplate = useCallback((id: string, isTemplate: boolean) => {
+    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, is_template: isTemplate } : s)));
+  }, []);
+
+  return {
+    songs: songs.filter((s) => matchesView(s, view, user)),
+    total,
+    loading,
+    loadingMore,
+    hasMore,
+    loadMore,
+    sentinelRef,
+    removeSong,
+    renameSong,
+    setSongTemplate,
+  };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -52,6 +52,9 @@ export type Translations = {
   feedMine: string;
   feedTemplates: string;
   noTemplates: string;
+  songsCount: (n: number) => string;
+  loadingMore: string;
+  showMore: string;
   templateBadge: string;
   templateOn: string;
   templateOff: string;
@@ -136,6 +139,9 @@ export const translations: Record<Locale, Translations> = {
     feedMine: "Mine",
     feedTemplates: "Templates",
     noTemplates: "No templates yet.",
+    songsCount: (n) => `${n} songs`,
+    loadingMore: "Loading more...",
+    showMore: "Show more",
     templateBadge: "Template",
     templateOn: "Make template",
     templateOff: "Unset template",
@@ -216,6 +222,9 @@ export const translations: Record<Locale, Translations> = {
     feedMine: "じぶん",
     feedTemplates: "テンプレ",
     noTemplates: "まだ テンプレートが ありません。",
+    songsCount: (n) => `${n}曲`,
+    loadingMore: "よみこみちゅう...",
+    showMore: "もっと見る",
     templateBadge: "テンプレ",
     templateOn: "テンプレにする",
     templateOff: "テンプレ解除",


### PR DESCRIPTION
Closes #65

## バグ

`/songs`（みんなのきょく）が `.limit(50)` 固定で、50曲を超えると表示されなかった（公開曲72件のうち22件が非表示）。

## 修正

- **ページング**：`.range()` で24件/ページ、新しい順。`count:"exact"` でツールバーに「N曲」表示
- **無限スクロール（IntersectionObserver）＋「もっと見る」ボタン**のハイブリッド：埋め込みwebviewでIOが発火しない環境向けに、ボタンを確実なフォールバック（＋キーボード/支援技術の導線）に
- **二重発火ガード**（`loadingMoreRef`）、追加時はidで重複除去
- **タブ切替でページリセット**（みんな/テンプレ/じぶん）
- **スケルトン読み込み**（初回はカード型プレースホルダ＋シマー）

## リファクタ

- データ層（ページング・fetch・IO・ミューテーション）を **`useSongFeed` カスタムフック**に抽出（`useSong`/`useProfile` と同じ規約）。`page.tsx` は表示＋配線に専念（158行削減）
- サーバー/クライアントのフィルタを単一の `matchesView()` に統一

## 検証

- [x] 全72曲ロード（24→48→72、ボタン消滅・重複なし）
- [x] タブ切替リセット（テンプレ=2曲、みんな=72曲）
- [x] モバイル/デスクトップ両レイアウト
- [x] リファクタ後の回帰なし・コンソールエラーなし
- [x] 型 / lint / vitest 57件

## 補足

自動スクロールのIntersectionObserverは、プレビュー環境ではコールバックが発火せず未検証（IOは全モダンブラウザ標準なので実機Chrome/Safariでは動作）。ただし「もっと見る」ボタン経由の全件ロードは検証済みで、どの環境でも全曲は必ず閲覧可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)