### PR TITLE
feat(songs): 曲名・作者のテキスト検索（サーバー側 ilike ＋デバウンス）

### DIFF
--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/hooks/useAuth";
@@ -38,6 +38,15 @@ export default function SongsPage() {
   const { profile, saveProfile } = useProfile(user);
   const [view, setView] = useState<FeedView>("all");
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  // `searchInput` tracks the field; `search` is the debounced value that
+  // actually drives the query, so we don't hit the DB on every keystroke.
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    const id = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(id);
+  }, [searchInput]);
 
   // "mine" needs sign-in; "all" and "templates" are open to everyone.
   const effectiveView: FeedView = !user && view === "mine" ? "all" : view;
@@ -53,7 +62,7 @@ export default function SongsPage() {
     removeSong,
     renameSong,
     setSongTemplate,
-  } = useSongFeed(effectiveView, user);
+  } = useSongFeed(effectiveView, user, search);
 
   // Identity line for the account menu, from whatever profile fields are set.
   const profileSubtitle = [
@@ -94,6 +103,29 @@ export default function SongsPage() {
       )}
 
       <main className="songs-main">
+        <div className="songs-search-wrap">
+          <span className="songs-search-icon" aria-hidden="true">
+            🔍
+          </span>
+          <input
+            type="search"
+            className="songs-search"
+            placeholder={t.searchPlaceholder}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            aria-label={t.searchPlaceholder}
+          />
+          {searchInput && (
+            <button
+              className="songs-search-clear"
+              onClick={() => setSearchInput("")}
+              aria-label={t.searchClear}
+            >
+              ×
+            </button>
+          )}
+        </div>
+
         <div className="songs-toolbar">
           <div className="songs-tabs">
             <button
@@ -137,11 +169,13 @@ export default function SongsPage() {
           </div>
         ) : songs.length === 0 ? (
           <p className="songs-status">
-            {effectiveView === "mine"
-              ? t.noMySongs
-              : effectiveView === "templates"
-                ? t.noTemplates
-                : t.noSongs}
+            {search
+              ? t.noResults
+              : effectiveView === "mine"
+                ? t.noMySongs
+                : effectiveView === "templates"
+                  ? t.noTemplates
+                  : t.noSongs}
           </p>
         ) : (
           <>

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -235,6 +235,67 @@
   background: var(--grid-line);
 }
 
+/* Search box above the filter tabs */
+.songs-search-wrap {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.songs-search-icon {
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 15px;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.songs-search {
+  width: 100%;
+  padding: 12px 44px;
+  border-radius: 22px;
+  border: 1.5px solid var(--grid-line);
+  background: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.15s ease;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.songs-search::-webkit-search-cancel-button {
+  display: none;
+}
+
+.songs-search:focus {
+  border-color: #667eea;
+}
+
+.songs-search-clear {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: var(--grid-line);
+  color: var(--foreground);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.songs-search-clear:hover {
+  opacity: 0.75;
+}
+
 /* Toolbar: filter tabs on the left, song count on the right */
 .songs-toolbar {
   display: flex;

--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -32,11 +32,21 @@ function matchesView(song: FeedSong, view: FeedView, user: User | null): boolean
   return !song.is_template; // "all" excludes templates
 }
 
+// Strip characters that would break the PostgREST `.or()` filter string
+// (comma separates terms, parens group them) or act as ilike wildcards, so the
+// term is matched literally. Capped to keep the query bounded.
+function sanitizeSearch(raw: string): string {
+  return raw
+    .replace(/[,()%*\\]/g, "")
+    .trim()
+    .slice(0, 60);
+}
+
 // Paginated songs feed for a view. Owns fetching, infinite scroll, and the
 // local mutations that keep the list in sync after a card edits itself.
 // Attach `sentinelRef` to an element near the list end for scroll auto-load;
 // call `loadMore()` from a button as a fallback where the observer can't fire.
-export function useSongFeed(view: FeedView, user: User | null) {
+export function useSongFeed(view: FeedView, user: User | null, search = "") {
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [total, setTotal] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -56,9 +66,11 @@ export function useSongFeed(view: FeedView, user: User | null) {
       if (view === "mine" && user) query = query.eq("user_id", user.id);
       else if (view === "templates") query = query.eq("is_template", true);
       else query = query.eq("is_template", false);
+      const term = sanitizeSearch(search);
+      if (term) query = query.or(`title.ilike.%${term}%,author.ilike.%${term}%`);
       return query.order("updated_at", { ascending: false }).range(from, from + PAGE_SIZE - 1);
     },
-    [view, user]
+    [view, user, search]
   );
 
   // Initial load, and reset whenever the view (or sign-in state) changes.

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -52,6 +52,9 @@ export type Translations = {
   feedMine: string;
   feedTemplates: string;
   noTemplates: string;
+  searchPlaceholder: string;
+  searchClear: string;
+  noResults: string;
   songsCount: (n: number) => string;
   loadingMore: string;
   showMore: string;
@@ -139,6 +142,9 @@ export const translations: Record<Locale, Translations> = {
     feedMine: "Mine",
     feedTemplates: "Templates",
     noTemplates: "No templates yet.",
+    searchPlaceholder: "Search by song or name",
+    searchClear: "Clear",
+    noResults: "No matching songs.",
     songsCount: (n) => `${n} songs`,
     loadingMore: "Loading more...",
     showMore: "Show more",
@@ -222,6 +228,9 @@ export const translations: Record<Locale, Translations> = {
     feedMine: "じぶん",
     feedTemplates: "テンプレ",
     noTemplates: "まだ テンプレートが ありません。",
+    searchPlaceholder: "きょくや なまえで さがす",
+    searchClear: "けす",
+    noResults: "みつかりませんでした。",
     songsCount: (n) => `${n}曲`,
     loadingMore: "よみこみちゅう...",
     showMore: "もっと見る",


### PR DESCRIPTION
Closes #67

## 概要

みんなのきょく（/songs）に、曲名・作者で探すテキスト検索を追加。

## 実装

- **サーバー側検索**：`title` / `author` への `ilike '%語%'`（OR）。ロード済みだけでなく**データセット全体**を対象にし、結果もページングされる
- `useSongFeed` に `search` パラメータを追加。変更でページングをリセット（タブ切替と同じ経路）
- `sanitizeSearch`：PostgREST の `.or()` を壊す文字（`,()`）や ilike ワイルドカード（`%*`）を除去して literal 一致に
- **300ms デバウンス**（打鍵ごとの問い合わせを防止）
- 検索専用の空状態、カウントは一致件数を反映
- 虫眼鏡＋クリア（×）付きのピル型検索ボックス（日英）

## スコープ外

- 読み仮名・ローマ字マッチはしない（「たなか」→「田中」は不一致）。素の部分一致
- 数万行規模になったら `pg_trgm` GIN インデックス（今回は不要）

## 検証（実データ・ブラウザ操作）

- [x] 「板村」→ 3曲（DB全体の一致数と一致、24件目以降の曲も含む＝全データセット検索を実証）
- [x] 「渡邉」→ 5曲
- [x] 「Bubble」→ 1曲（大文字小文字非依存）
- [x] 「zzzxxx」→ 0件で「みつかりませんでした。」
- [x] クリアで全72曲へ復帰
- [x] 型 / lint / vitest 57件、コンソールエラーなし

前提：#65（`useSongFeed`）。次タスク：#68（学年・クラス絞り込み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)