### PR TITLE
feat(songs): 学年・クラスで絞り込み（保存時スナップショットを曲へ非正規化）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,11 @@ Playful, rounded, kid-friendly. Keep new UI consistent with these:
 - Both `/` and `/songs` pages share the account menu (locale switch works signed out too)
 
 ## Save / Feed
-- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at, updated_at)
+- Songs are saved to Supabase table `songs` (columns: id, title, author, song_data jsonb, created_at, updated_at, grade, class_name)
   - `updated_at` is server-controlled (trigger): bumped only when title/author/song_data change (overwrite-save, rename) — not by hidden/is_template flips
+  - `grade`/`class_name` are a **snapshot of the author's profile at save time** (trigger `songs_class_snapshot`): populated on insert from `profiles`, frozen on update, null for anonymous saves. The client never sends them.
 - Public read + insert RLS policies (no auth required)
-- `/songs` page paginates all songs newest-first (24/page via `.range()`, infinite scroll + "もっと見る" fallback); each card links to `/?load=<id>`
+- `/songs` page: server-side text search (`ilike` title/author, debounced) + grade/class filters (`song_class_options()` RPC feeds the dropdowns; hidden when no class data); all fold into `useSongFeed`, paginated 24/page via `.range()` (infinite scroll + "もっと見る" fallback); each card links to `/?load=<id>`
 - Editor loads a song via `?load=<id>` on mount **through `migrateSong()`**, then cleans the URL with `replaceState`
 - Required env vars: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -5,7 +5,12 @@ import Link from "next/link";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
-import { useSongFeed, type FeedView } from "@/hooks/useSongFeed";
+import {
+  useSongFeed,
+  fetchClassOptions,
+  type FeedView,
+  type ClassOption,
+} from "@/hooks/useSongFeed";
 import { AccountMenu } from "@/app/components/AccountMenu";
 import { ProfileModal } from "@/app/components/ProfileModal";
 import { SongCard } from "@/app/components/SongCard";
@@ -42,11 +47,36 @@ export default function SongsPage() {
   // actually drives the query, so we don't hit the DB on every keystroke.
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
+  const [grade, setGrade] = useState<number | null>(null);
+  const [className, setClassName] = useState<string | null>(null);
+  const [classOptions, setClassOptions] = useState<ClassOption[]>([]);
 
   useEffect(() => {
     const id = setTimeout(() => setSearch(searchInput), 300);
     return () => clearTimeout(id);
   }, [searchInput]);
+
+  useEffect(() => {
+    let active = true;
+    fetchClassOptions().then((opts) => {
+      if (active) setClassOptions(opts);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Distinct grades, and the classes available for the selected grade.
+  const grades = [...new Set(classOptions.map((o) => o.grade).filter((g): g is number => g != null))];
+  const classNames = [
+    ...new Set(
+      classOptions
+        .filter((o) => grade == null || o.grade === grade)
+        .map((o) => o.className)
+        .filter((c): c is string => c != null)
+    ),
+  ];
+  const hasClassFilters = grades.length > 0 || classNames.length > 0;
 
   // "mine" needs sign-in; "all" and "templates" are open to everyone.
   const effectiveView: FeedView = !user && view === "mine" ? "all" : view;
@@ -62,7 +92,7 @@ export default function SongsPage() {
     removeSong,
     renameSong,
     setSongTemplate,
-  } = useSongFeed(effectiveView, user, search);
+  } = useSongFeed(effectiveView, user, { search, grade, className });
 
   // Identity line for the account menu, from whatever profile fields are set.
   const profileSubtitle = [
@@ -149,6 +179,45 @@ export default function SongsPage() {
               </button>
             )}
           </div>
+
+          {hasClassFilters && (
+            <div className="songs-filters">
+              {grades.length > 0 && (
+                <select
+                  className="songs-filter-select"
+                  value={grade ?? ""}
+                  onChange={(e) => {
+                    setGrade(e.target.value === "" ? null : Number(e.target.value));
+                    setClassName(null); // classes depend on grade
+                  }}
+                  aria-label={t.profileGrade}
+                >
+                  <option value="">{t.filterGradeAll}</option>
+                  {grades.map((g) => (
+                    <option key={g} value={g}>
+                      {t.profileGradeUnit(g)}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {classNames.length > 0 && (
+                <select
+                  className="songs-filter-select"
+                  value={className ?? ""}
+                  onChange={(e) => setClassName(e.target.value === "" ? null : e.target.value)}
+                  aria-label={t.profileClass}
+                >
+                  <option value="">{t.filterClassAll}</option>
+                  {classNames.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+          )}
+
           {!loading && total != null && songs.length > 0 && (
             <span className="songs-count">{t.songsCount(total)}</span>
           )}

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useLocale } from "@/hooks/useLocale";
 import { useAuth } from "@/hooks/useAuth";
 import { useProfile } from "@/hooks/useProfile";
-import {
-  useSongFeed,
-  fetchClassOptions,
-  type FeedView,
-  type ClassOption,
-} from "@/hooks/useSongFeed";
+import { useSongFeed, type FeedView } from "@/hooks/useSongFeed";
+import { useSongFilters } from "@/hooks/useSongFilters";
 import { AccountMenu } from "@/app/components/AccountMenu";
 import { ProfileModal } from "@/app/components/ProfileModal";
 import { SongCard } from "@/app/components/SongCard";
@@ -43,40 +39,19 @@ export default function SongsPage() {
   const { profile, saveProfile } = useProfile(user);
   const [view, setView] = useState<FeedView>("all");
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
-  // `searchInput` tracks the field; `search` is the debounced value that
-  // actually drives the query, so we don't hit the DB on every keystroke.
-  const [searchInput, setSearchInput] = useState("");
-  const [search, setSearch] = useState("");
-  const [grade, setGrade] = useState<number | null>(null);
-  const [className, setClassName] = useState<string | null>(null);
-  const [classOptions, setClassOptions] = useState<ClassOption[]>([]);
 
-  useEffect(() => {
-    const id = setTimeout(() => setSearch(searchInput), 300);
-    return () => clearTimeout(id);
-  }, [searchInput]);
-
-  useEffect(() => {
-    let active = true;
-    fetchClassOptions().then((opts) => {
-      if (active) setClassOptions(opts);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  // Distinct grades, and the classes available for the selected grade.
-  const grades = [...new Set(classOptions.map((o) => o.grade).filter((g): g is number => g != null))];
-  const classNames = [
-    ...new Set(
-      classOptions
-        .filter((o) => grade == null || o.grade === grade)
-        .map((o) => o.className)
-        .filter((c): c is string => c != null)
-    ),
-  ];
-  const hasClassFilters = grades.length > 0 || classNames.length > 0;
+  const {
+    filters,
+    searchInput,
+    setSearchInput,
+    grade,
+    selectGrade,
+    className,
+    setClassName,
+    grades,
+    classNames,
+    hasClassFilters,
+  } = useSongFilters();
 
   // "mine" needs sign-in; "all" and "templates" are open to everyone.
   const effectiveView: FeedView = !user && view === "mine" ? "all" : view;
@@ -92,7 +67,7 @@ export default function SongsPage() {
     removeSong,
     renameSong,
     setSongTemplate,
-  } = useSongFeed(effectiveView, user, { search, grade, className });
+  } = useSongFeed(effectiveView, user, filters);
 
   // Identity line for the account menu, from whatever profile fields are set.
   const profileSubtitle = [
@@ -186,10 +161,7 @@ export default function SongsPage() {
                 <select
                   className="songs-filter-select"
                   value={grade ?? ""}
-                  onChange={(e) => {
-                    setGrade(e.target.value === "" ? null : Number(e.target.value));
-                    setClassName(null); // classes depend on grade
-                  }}
+                  onChange={(e) => selectGrade(e.target.value === "" ? null : Number(e.target.value))}
                   aria-label={t.profileGrade}
                 >
                   <option value="">{t.filterGradeAll}</option>
@@ -238,7 +210,7 @@ export default function SongsPage() {
           </div>
         ) : songs.length === 0 ? (
           <p className="songs-status">
-            {search
+            {filters.search
               ? t.noResults
               : effectiveView === "mine"
                 ? t.noMySongs

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -296,11 +296,10 @@
   opacity: 0.75;
 }
 
-/* Toolbar: filter tabs on the left, song count on the right */
+/* Toolbar: tabs + class filters on the left, song count pushed to the right */
 .songs-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   margin-bottom: 20px;
   flex-wrap: wrap;
@@ -311,6 +310,39 @@
   font-weight: 700;
   opacity: 0.5;
   white-space: nowrap;
+  margin-left: auto;
+}
+
+.songs-filters {
+  display: flex;
+  gap: 8px;
+}
+
+.songs-filter-select {
+  padding: 8px 32px 8px 14px;
+  border-radius: 20px;
+  border: 1.5px solid var(--grid-line);
+  background-color: var(--grid-bg);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--foreground) 50%),
+    linear-gradient(135deg, var(--foreground) 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) 50%,
+    calc(100% - 13px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px;
+  background-repeat: no-repeat;
+  transition: border-color 0.15s ease;
+}
+
+.songs-filter-select:focus {
+  border-color: #667eea;
 }
 
 /* My/All filter tabs */

--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -46,7 +46,27 @@ function sanitizeSearch(raw: string): string {
 // local mutations that keep the list in sync after a card edits itself.
 // Attach `sentinelRef` to an element near the list end for scroll auto-load;
 // call `loadMore()` from a button as a fallback where the observer can't fire.
-export function useSongFeed(view: FeedView, user: User | null, search = "") {
+export type ClassOption = { grade: number | null; className: string | null };
+
+// Distinct grade/class pairs present in the feed, for the filter dropdowns
+// (computed in the DB so it stays cheap as the table grows).
+export async function fetchClassOptions(): Promise<ClassOption[]> {
+  const { data, error } = await supabase.rpc("song_class_options");
+  if (error || !data) return [];
+  return (data as { grade: number | null; class_name: string | null }[]).map((r) => ({
+    grade: r.grade,
+    className: r.class_name,
+  }));
+}
+
+export type FeedFilters = {
+  search?: string;
+  grade?: number | null;
+  className?: string | null;
+};
+
+export function useSongFeed(view: FeedView, user: User | null, filters: FeedFilters = {}) {
+  const { search = "", grade = null, className = null } = filters;
   const [songs, setSongs] = useState<FeedSong[]>([]);
   const [total, setTotal] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -68,9 +88,11 @@ export function useSongFeed(view: FeedView, user: User | null, search = "") {
       else query = query.eq("is_template", false);
       const term = sanitizeSearch(search);
       if (term) query = query.or(`title.ilike.%${term}%,author.ilike.%${term}%`);
+      if (grade != null) query = query.eq("grade", grade);
+      if (className) query = query.eq("class_name", className);
       return query.order("updated_at", { ascending: false }).range(from, from + PAGE_SIZE - 1);
     },
-    [view, user, search]
+    [view, user, search, grade, className]
   );
 
   // Initial load, and reset whenever the view (or sign-in state) changes.

--- a/src/hooks/useSongFilters.ts
+++ b/src/hooks/useSongFilters.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchClassOptions, type ClassOption, type FeedFilters } from "@/hooks/useSongFeed";
+
+// Owns the feed's search/filter controls: a debounced text query and the
+// grade/class dropdowns (whose options come from the songs that exist).
+// Returns `filters` to hand straight to useSongFeed, plus the state and
+// derived option lists the toolbar renders.
+export function useSongFilters() {
+  // `searchInput` tracks the field; `search` is the debounced value that
+  // actually drives the query, so we don't hit the DB on every keystroke.
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [grade, setGrade] = useState<number | null>(null);
+  const [className, setClassName] = useState<string | null>(null);
+  const [classOptions, setClassOptions] = useState<ClassOption[]>([]);
+
+  useEffect(() => {
+    const id = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(id);
+  }, [searchInput]);
+
+  useEffect(() => {
+    let active = true;
+    fetchClassOptions().then((opts) => {
+      if (active) setClassOptions(opts);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Distinct grades, and the classes available for the selected grade.
+  const grades = [...new Set(classOptions.map((o) => o.grade).filter((g): g is number => g != null))];
+  const classNames = [
+    ...new Set(
+      classOptions
+        .filter((o) => grade == null || o.grade === grade)
+        .map((o) => o.className)
+        .filter((c): c is string => c != null)
+    ),
+  ];
+
+  // Picking a grade clears a class that no longer belongs to it.
+  const selectGrade = useCallback((next: number | null) => {
+    setGrade(next);
+    setClassName(null);
+  }, []);
+
+  const filters: FeedFilters = { search, grade, className };
+
+  return {
+    filters,
+    searchInput,
+    setSearchInput,
+    grade,
+    selectGrade,
+    className,
+    setClassName,
+    grades,
+    classNames,
+    hasClassFilters: grades.length > 0 || classNames.length > 0,
+  };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -55,6 +55,8 @@ export type Translations = {
   searchPlaceholder: string;
   searchClear: string;
   noResults: string;
+  filterGradeAll: string;
+  filterClassAll: string;
   songsCount: (n: number) => string;
   loadingMore: string;
   showMore: string;
@@ -145,6 +147,8 @@ export const translations: Record<Locale, Translations> = {
     searchPlaceholder: "Search by song or name",
     searchClear: "Clear",
     noResults: "No matching songs.",
+    filterGradeAll: "All grades",
+    filterClassAll: "All classes",
     songsCount: (n) => `${n} songs`,
     loadingMore: "Loading more...",
     showMore: "Show more",
@@ -231,6 +235,8 @@ export const translations: Record<Locale, Translations> = {
     searchPlaceholder: "きょくや なまえで さがす",
     searchClear: "けす",
     noResults: "みつかりませんでした。",
+    filterGradeAll: "すべての学年",
+    filterClassAll: "すべてのクラス",
     songsCount: (n) => `${n}曲`,
     loadingMore: "よみこみちゅう...",
     showMore: "もっと見る",

--- a/supabase/migrations/0006_songs_class_snapshot.sql
+++ b/supabase/migrations/0006_songs_class_snapshot.sql
@@ -1,0 +1,82 @@
+-- Snapshot the author's grade/class onto each song so the feed can be filtered
+-- by class (e.g. "3年2組"). Applied to the BeatBubble Supabase project.
+--
+-- Denormalized on purpose: a song made in 3年 stays a 3年 work after the child
+-- moves up a grade. Server-controlled via a trigger — the client never sends
+-- these (can't be spoofed), and they're frozen at creation (updates preserve
+-- them). Anonymous songs (user_id null) have no class.
+
+alter table public.songs add column if not exists grade smallint;
+alter table public.songs add column if not exists class_name text;
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'songs_grade_range') then
+    alter table public.songs
+      add constraint songs_grade_range check (grade is null or (grade between 1 and 6));
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'songs_class_name_len') then
+    alter table public.songs
+      add constraint songs_class_name_len check (class_name is null or char_length(class_name) <= 40);
+  end if;
+end $$;
+
+-- INSERT: copy the author's current grade/class from their profile.
+-- UPDATE: keep the snapshot frozen, ignoring any client-sent change.
+create or replace function public.songs_class_snapshot()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'INSERT' then
+    if new.user_id is not null then
+      select p.grade, p.class_name
+        into new.grade, new.class_name
+        from public.profiles p
+        where p.id = new.user_id;
+    end if;
+  else
+    new.grade := old.grade;
+    new.class_name := old.class_name;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists songs_class_snapshot_ins on public.songs;
+create trigger songs_class_snapshot_ins
+  before insert on public.songs
+  for each row execute function public.songs_class_snapshot();
+
+-- Backfill existing songs from their author's current profile. Runs before the
+-- UPDATE trigger exists, so the preserve-old-values branch can't undo it.
+-- (The updated_at trigger only bumps on title/author/song_data changes, so
+--  ordering of the feed is unaffected.)
+update public.songs s
+set grade = p.grade, class_name = p.class_name
+from public.profiles p
+where s.user_id = p.id and s.user_id is not null;
+
+drop trigger if exists songs_class_snapshot_upd on public.songs;
+create trigger songs_class_snapshot_upd
+  before update on public.songs
+  for each row execute function public.songs_class_snapshot();
+
+-- Distinct grade/class pairs present in the visible feed, for the filter UI.
+-- Done in the DB (not by fetching every row) so it stays cheap as songs grow.
+create or replace function public.song_class_options()
+returns table (grade smallint, class_name text)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select distinct s.grade, s.class_name
+  from public.songs s
+  where s.hidden = false and (s.grade is not null or s.class_name is not null)
+  order by s.grade nulls last, s.class_name nulls last;
+$$;
+
+grant execute on function public.song_class_options() to anon, authenticated;


### PR DESCRIPTION
Closes #68

## 概要

みんなのきょく（/songs）を学年・クラスで絞り込めるようにする（例：「3年2組の曲」）。

## 設計：曲側へスナップショット（非正規化）

作者の学年・クラスを、JOINではなく**保存時に曲行へコピー（スナップショット）**する。「3年のときに作った曲」は本人が4年に上がっても *3年の作品* のまま残る、という意味的正しさ＋クエリ単純化のため。

## 実装

- **マイグレーション 0006**：`songs.grade` / `class_name` 追加。トリガー `songs_class_snapshot` が
  - INSERT時：`profiles` から作者の学年・クラスを埋める（サーバー権威・**クライアントは送らない＝改ざん不可**）
  - UPDATE時：スナップショットを凍結（上書き保存でも変えない）
  - 匿名保存（user_id null）は null
  - 既存行はバックフィル
- **`song_class_options()` RPC**：存在する distinct な学年/クラスの組をDB側で返し（スケールする）、ドロップダウンを生成。**クラスデータが無ければフィルタ行ごと非表示**
- **`useSongFeed`**：`{ search, grade, className }` のフィルタオブジェクトを受け取り、`.eq()` で絞る。学年選択でクラス選択肢が絞られ、フィルタ変更でページングをリセット
- 保存フローの改修は不要（トリガーが担う）

## 注意（PR本文にも明記）

- **匿名保存の曲はクラス不明（null）**＝クラス絞り込みの対象外。効くのはログイン児童の曲
- 個人情報：公開フィードの曲行に学年・クラスが載る。児童名（author）と組み合わさると識別性が上がる点は留意（現状は既に author を公開している範囲内）

## 検証

- [x] トリガー（INSERTスナップショット／UPDATE保持／匿名null）をロールバックTxで検証
- [x] `song_class_options()` RPC が distinct を正しく返す＋`.eq` フィルタのカウント一致（ロールバックTx）
- [x] ドロップダウン配線をブラウザで検証：学年選択でクラス選択肢が絞られる、クエリに `grade=eq.N&class_name=eq.M` が range ページングと共に乗る
- [x] 型 / lint / vitest 57件
- [x] 本番DBはクリーン（テストは全てロールバック、シード漏れなし）

前提：#65（`useSongFeed`）、#61（profiles）、#67（検索）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)