### PR TITLE
feat(songs): 可視性の基盤（draft/unlisted/public）— PR-1 基盤

### DIFF
--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -16,12 +16,14 @@ export type FeedSong = {
   song_data: Song;
   user_id: string | null;
   is_template: boolean;
+  visibility: "draft" | "unlisted" | "public";
 };
 
 // How many songs to fetch per page. The feed loads more as you scroll.
 const PAGE_SIZE = 24;
 
-const SONG_COLUMNS = "id, title, author, created_at, updated_at, song_data, user_id, is_template";
+const SONG_COLUMNS =
+  "id, title, author, created_at, updated_at, song_data, user_id, is_template, visibility";
 
 // Whether a song belongs to a view — mirrors the server-side filter, so a
 // locally-mutated song (template toggled, etc.) leaves/stays in the list
@@ -83,9 +85,15 @@ export function useSongFeed(view: FeedView, user: User | null, filters: FeedFilt
   const fetchPage = useCallback(
     (from: number) => {
       let query = supabase.from("songs").select(SONG_COLUMNS, { count: "exact" });
-      if (view === "mine" && user) query = query.eq("user_id", user.id);
-      else if (view === "templates") query = query.eq("is_template", true);
-      else query = query.eq("is_template", false);
+      if (view === "mine" && user) {
+        // "mine" shows the owner's songs at any visibility (drafts included).
+        query = query.eq("user_id", user.id);
+      } else {
+        // Public feeds show only public songs — unlisted is reachable by link
+        // only (RLS allows the read; this filter keeps it out of the feed),
+        // and drafts aren't world-readable at all.
+        query = query.eq("is_template", view === "templates").eq("visibility", "public");
+      }
       const term = sanitizeSearch(search);
       if (term) query = query.or(`title.ilike.%${term}%,author.ilike.%${term}%`);
       if (grade != null) query = query.eq("grade", grade);

--- a/supabase/migrations/0007_songs_visibility.sql
+++ b/supabase/migrations/0007_songs_visibility.sql
@@ -1,0 +1,59 @@
+-- Song visibility: draft / unlisted / public. Applied to the BeatBubble
+-- Supabase project. Separate from `hidden` (moderation): visibility is
+-- owner-controlled, hidden is admin-controlled and owners can't clear it.
+--
+-- Foundation only: existing behaviour is unchanged. Every row defaults to
+-- 'public', and the feed query restricts to 'public', so today's public songs
+-- stay public. The save flow keeps inserting public songs until the draft UX
+-- lands (so no song is ever stranded without a way to publish).
+--
+-- Visibility rule (enforced partly by RLS, partly by the feed query):
+--   public   → in the feed AND reachable by link
+--   unlisted → NOT in the feed, reachable by /?load=<id> (RLS allows the read;
+--              the feed query filters visibility='public' to keep it out)
+--   draft    → owner only
+
+alter table public.songs add column if not exists visibility text not null default 'public';
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'songs_visibility_values') then
+    alter table public.songs
+      add constraint songs_visibility_values check (visibility in ('draft', 'unlisted', 'public'));
+  end if;
+  -- draft/unlisted require an owner (an anonymous private song is unreachable).
+  if not exists (select 1 from pg_constraint where conname = 'songs_visibility_owner') then
+    alter table public.songs
+      add constraint songs_visibility_owner check (visibility = 'public' or user_id is not null);
+  end if;
+  -- Templates must be public (they're meant to be reusable by everyone).
+  if not exists (select 1 from pg_constraint where conname = 'songs_template_public') then
+    alter table public.songs
+      add constraint songs_template_public check (is_template = false or visibility = 'public');
+  end if;
+end $$;
+
+-- Public + unlisted are world-readable; drafts are not. The feed query further
+-- restricts to 'public' so unlisted is reachable only by direct link.
+drop policy if exists "public read visible" on public.songs;
+create policy "public read visible" on public.songs
+  for select to public
+  using (hidden = false and visibility in ('public', 'unlisted'));
+
+-- Owners can read their own songs at any visibility (for the "mine" tab).
+drop policy if exists "owner read own" on public.songs;
+create policy "owner read own" on public.songs
+  for select to public
+  using (auth.uid() = user_id and hidden = false);
+
+-- Insert: anon may post only public; a signed-in user may post any visibility
+-- for their own rows. (Preserves the existing hidden/ownership/template checks.)
+drop policy if exists "insert own or anon" on public.songs;
+create policy "insert own or anon" on public.songs
+  for insert to public
+  with check (
+    hidden = false
+    and (user_id is null or user_id = auth.uid())
+    and (is_template = false or user_id = auth.uid())
+    and (visibility = 'public' or user_id = auth.uid())
+  );


### PR DESCRIPTION
#71 の PR-1（基盤）。**ユーザーに見える挙動の変更はまだ無し**（安全な土台）。

## 内容

- **マイグレーション 0007**：`songs.visibility text ('draft'|'unlisted'|'public')`、default `'public'`（既存・新規とも公開のまま）。CHECK：値の妥当性／draft・unlisted は所有者必須／テンプレは public 必須
- **RLS**：
  - 公開読取：`hidden=false AND visibility IN ('public','unlisted')`（draft は所有者以外読めない）
  - owner-read ポリシー新設：`auth.uid()=user_id AND hidden=false`（所有者は自分の draft/unlisted/public を閲覧）
  - insert：匿名は public のみ、ログインは自分の行なら任意の visibility
- **`useSongFeed`**：visibility を select、公開フィード（みんな/テンプレ）に `.eq('visibility','public')` を追加。「じぶん」は所有者の全 visibility。**unlisted はリンクのみ到達（RLSは読取許可、フィード除外はこのクエリが担保）**

## なぜ挙動を変えないか

保存を draft 既定にするなら公開UIと同時でないと「保存した曲を公開する手段がない」宙吊りになる。よって PR-1 は基盤のみ、**保存draft既定＋可視性ピッカー＋バッジ＋リンク共有は PR-2 で一括**。

## 検証

- [x] マイグレーション適用済み
- [x] RLS（ロールバックTx）：anon は public+unlisted 可・draft 不可／owner は3種可／匿名の draft 挿入は拒否
- [x] ブラウザ：公開フィード不変（クエリに `visibility=eq.public`）、テンプレ2曲
- [x] 型 / lint / vitest 57件、コンソールエラーなし

前提：#71。次：PR-2（保存 draft 既定＋可視性ピッカー＋バッジ＋リンク）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)