### PR TITLE
feat(songs): 下書き/限定公開/公開 UX — 保存は非公開、あとで公開（PR-2）

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -81,6 +81,9 @@ export function SaveModal({
         author: author.trim(),
         song_data: song,
         user_id: userId,
+        // Signed-in saves start private (publish later); anonymous saves have
+        // no owner to manage a draft, so they go straight to public.
+        visibility: userId ? "draft" : "public",
       })
     );
 
@@ -123,6 +126,9 @@ export function SaveModal({
             maxLength={MAX_AUTHOR_LENGTH}
           />
         </div>
+        {!existing && (
+          <p className="modal-hint">{userId ? t.saveDraftHint : t.savePublicHint}</p>
+        )}
         {error && <p className="modal-error">{error}</p>}
         <div className="modal-actions">
           <button className="modal-cancel" onClick={onClose}>

--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import type { Translations } from "@/lib/i18n";
+import type { Visibility } from "@/hooks/useSongFeed";
 import { supabase } from "@/lib/supabase";
 import { MAX_TITLE_LENGTH, validateSongMeta } from "@/lib/validation";
-
-export type Visibility = "draft" | "unlisted" | "public";
 
 interface Props {
   id: string;

--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -6,6 +6,8 @@ import type { Translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
 import { MAX_TITLE_LENGTH, validateSongMeta } from "@/lib/validation";
 
+export type Visibility = "draft" | "unlisted" | "public";
+
 interface Props {
   id: string;
   title: string;
@@ -14,13 +16,17 @@ interface Props {
   gradient: string;
   isOwner: boolean;
   isTemplate: boolean;
+  visibility: Visibility;
   t: Translations;
   onDeleted: (id: string) => void;
   onRenamed: (id: string, title: string) => void;
   onTemplateToggled: (id: string, isTemplate: boolean) => void;
+  onVisibilityChanged: (id: string, visibility: Visibility) => void;
 }
 
 type Mode = "view" | "rename" | "confirmDelete";
+
+const VISIBILITY_ORDER: Visibility[] = ["public", "unlisted", "draft"];
 
 export function SongCard({
   id,
@@ -30,10 +36,12 @@ export function SongCard({
   gradient,
   isOwner,
   isTemplate,
+  visibility,
   t,
   onDeleted,
   onRenamed,
   onTemplateToggled,
+  onVisibilityChanged,
 }: Props) {
   const [mode, setMode] = useState<Mode>("view");
   const [draft, setDraft] = useState(title);
@@ -95,10 +103,28 @@ export function SongCard({
     if (!error) onTemplateToggled(id, next);
   };
 
+  const changeVisibility = async (next: Visibility) => {
+    setMenuOpen(false);
+    if (next === visibility) return;
+    setBusy(true);
+    const { error } = await supabase.from("songs").update({ visibility: next }).eq("id", id);
+    setBusy(false);
+    if (!error) onVisibilityChanged(id, next);
+  };
+
+  const visLabel = (v: Visibility) =>
+    v === "public" ? t.visPublic : v === "unlisted" ? t.visUnlisted : t.visDraft;
+
   return (
     <div className="song-card">
       <div className="song-card-art" style={{ background: gradient }}>
-        {isTemplate && <span className="song-card-template-badge">{t.templateBadge}</span>}
+        {isTemplate ? (
+          <span className="song-card-template-badge">{t.templateBadge}</span>
+        ) : visibility === "draft" ? (
+          <span className="song-card-vis-badge draft">{t.visDraft}</span>
+        ) : visibility === "unlisted" ? (
+          <span className="song-card-vis-badge unlisted">{t.visUnlisted}</span>
+        ) : null}
         {isOwner && (
           <div className="song-card-menu" ref={menuRef}>
             <button
@@ -112,6 +138,26 @@ export function SongCard({
             </button>
             {menuOpen && (
               <div className="song-card-menu-pop" role="menu">
+                {!isTemplate && (
+                  <>
+                    <span className="song-card-menu-label">{t.visibilityLabel}</span>
+                    {VISIBILITY_ORDER.map((v) => (
+                      <button
+                        key={v}
+                        role="menuitemradio"
+                        aria-checked={visibility === v}
+                        onClick={() => changeVisibility(v)}
+                        disabled={busy}
+                      >
+                        <span className="song-card-menu-check" aria-hidden="true">
+                          {visibility === v ? "✓" : ""}
+                        </span>
+                        {visLabel(v)}
+                      </button>
+                    ))}
+                    <div className="song-card-menu-divider" />
+                  </>
+                )}
                 <button role="menuitem" onClick={toggleTemplate} disabled={busy}>
                   {isTemplate ? `★ ${t.templateOff}` : `☆ ${t.templateOn}`}
                 </button>

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -67,6 +67,7 @@ export default function SongsPage() {
     removeSong,
     renameSong,
     setSongTemplate,
+    setSongVisibility,
   } = useSongFeed(effectiveView, user, filters);
 
   // Identity line for the account menu, from whatever profile fields are set.
@@ -231,10 +232,12 @@ export default function SongsPage() {
                   gradient={CARD_GRADIENTS[i % CARD_GRADIENTS.length]}
                   isOwner={!!user && song.user_id === user.id}
                   isTemplate={song.is_template}
+                  visibility={song.visibility}
                   t={t}
                   onDeleted={removeSong}
                   onRenamed={renameSong}
                   onTemplateToggled={setSongTemplate}
+                  onVisibilityChanged={setSongVisibility}
                 />
               ))}
             </div>

--- a/src/app/styles/modal.css
+++ b/src/app/styles/modal.css
@@ -110,6 +110,14 @@ select.modal-input {
   color: #ee5253;
 }
 
+.modal-hint {
+  margin: -4px 0 0;
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0.6;
+  line-height: 1.5;
+}
+
 .modal-save {
   padding: 8px 20px;
   border-radius: 12px;

--- a/src/app/styles/songs.css
+++ b/src/app/styles/songs.css
@@ -167,6 +167,52 @@
   letter-spacing: 0.02em;
 }
 
+/* Visibility badge (draft / unlisted) — same slot as the template badge */
+.song-card-vis-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 8px;
+  border-radius: 10px;
+  color: white;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.song-card-vis-badge.draft {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.song-card-vis-badge.unlisted {
+  background: rgba(24, 95, 165, 0.85);
+}
+
+/* Section label + radio check inside the owner menu */
+.song-card-menu-label {
+  padding: 6px 10px 2px;
+  font-size: 11px;
+  font-weight: 700;
+  opacity: 0.5;
+}
+
+.song-card-menu-check {
+  display: inline-block;
+  width: 14px;
+  color: #11998e;
+  font-weight: 700;
+}
+
+.song-card-menu-pop button[aria-checked="true"] {
+  color: #11998e;
+}
+
+.song-card-menu-divider {
+  height: 1px;
+  background: var(--grid-line);
+  margin: 4px 2px;
+}
+
 .song-card-body {
   padding: 16px;
   display: flex;

--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -7,6 +7,8 @@ import type { Song } from "@/core/types";
 
 export type FeedView = "all" | "mine" | "templates";
 
+export type Visibility = "draft" | "unlisted" | "public";
+
 export type FeedSong = {
   id: string;
   title: string;
@@ -16,7 +18,7 @@ export type FeedSong = {
   song_data: Song;
   user_id: string | null;
   is_template: boolean;
-  visibility: "draft" | "unlisted" | "public";
+  visibility: Visibility;
 };
 
 // How many songs to fetch per page. The feed loads more as you scroll.
@@ -176,7 +178,7 @@ export function useSongFeed(view: FeedView, user: User | null, filters: FeedFilt
     setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, is_template: isTemplate } : s)));
   }, []);
 
-  const setSongVisibility = useCallback((id: string, visibility: FeedSong["visibility"]) => {
+  const setSongVisibility = useCallback((id: string, visibility: Visibility) => {
     setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, visibility } : s)));
   }, []);
 

--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -30,8 +30,10 @@ const SONG_COLUMNS =
 // immediately without waiting for a refetch.
 function matchesView(song: FeedSong, view: FeedView, user: User | null): boolean {
   if (view === "mine") return !!user && song.user_id === user.id;
-  if (view === "templates") return song.is_template;
-  return !song.is_template; // "all" excludes templates
+  // Public feeds show only public songs, so a song switched to draft/unlisted
+  // drops out immediately without waiting for a refetch.
+  if (view === "templates") return song.is_template && song.visibility === "public";
+  return !song.is_template && song.visibility === "public"; // "all" excludes templates
 }
 
 // Strip characters that would break the PostgREST `.or()` filter string
@@ -174,6 +176,10 @@ export function useSongFeed(view: FeedView, user: User | null, filters: FeedFilt
     setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, is_template: isTemplate } : s)));
   }, []);
 
+  const setSongVisibility = useCallback((id: string, visibility: FeedSong["visibility"]) => {
+    setSongs((prev) => prev.map((s) => (s.id === id ? { ...s, visibility } : s)));
+  }, []);
+
   return {
     songs: songs.filter((s) => matchesView(s, view, user)),
     total,
@@ -185,5 +191,6 @@ export function useSongFeed(view: FeedView, user: User | null, filters: FeedFilt
     removeSong,
     renameSong,
     setSongTemplate,
+    setSongVisibility,
   };
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -63,6 +63,12 @@ export type Translations = {
   templateBadge: string;
   templateOn: string;
   templateOff: string;
+  visPublic: string;
+  visUnlisted: string;
+  visDraft: string;
+  visibilityLabel: string;
+  saveDraftHint: string;
+  savePublicHint: string;
   rename: string;
   deleteSong: string;
   confirmDeleteSong: string;
@@ -155,6 +161,12 @@ export const translations: Record<Locale, Translations> = {
     templateBadge: "Template",
     templateOn: "Make template",
     templateOff: "Unset template",
+    visPublic: "Public",
+    visUnlisted: "Unlisted",
+    visDraft: "Draft",
+    visibilityLabel: "Visibility",
+    saveDraftHint: "Saved as a draft. You can publish it later from Everyone's Songs.",
+    savePublicHint: "This will be published to Everyone's Songs.",
     rename: "Rename",
     deleteSong: "Delete",
     confirmDeleteSong: "Delete this song?",
@@ -243,6 +255,12 @@ export const translations: Record<Locale, Translations> = {
     templateBadge: "テンプレ",
     templateOn: "テンプレにする",
     templateOff: "テンプレ解除",
+    visPublic: "公開",
+    visUnlisted: "限定公開",
+    visDraft: "下書き",
+    visibilityLabel: "公開はんい",
+    saveDraftHint: "下書きとして保存します。あとで「みんなの曲」で公開できます。",
+    savePublicHint: "保存すると「みんなの曲」に公開されます。",
     rename: "なまえをかえる",
     deleteSong: "けす",
     confirmDeleteSong: "この曲を けしますか？",


### PR DESCRIPTION
Closes #71（PR-1 #72 の上に積む）

## 概要

「保存＝即公開」をやめ、**ログインユーザーは下書きで保存 → あとで公開**できるようにする完成版UX。

## 変更

- **保存**：ログイン新規保存は `visibility='draft'`（非公開）で保存。匿名は従来どおり `public`。SaveModal に説明（`saveDraftHint`/`savePublicHint`）
- **可視性ピッカー**：所有者のカードのケバブメニューに 公開／限定公開／下書き（ラジオ・現在値に✓）。下書き/限定公開はカードにバッジ表示。テンプレは公開固定なのでピッカー非表示（DBの check と一致）
- **`useSongFeed.setSongVisibility`**：ローカル状態を更新。`matchesView` も公開ビューで `visibility='public'` を要求 → 下書き/限定公開に切り替えた曲は みんな/テンプレ から即座に外れる
- **上書き保存**：visibility は変更しない（ピッカーだけが変える）

## 挙動まとめ

| 状態 | フィード | リンク `/?load=<id>` |
|---|---|---|
| 公開 | 出る | 誰でも可 |
| 限定公開 | 出ない | 誰でも可（リンク知る人） |
| 下書き | 出ない | 所有者のみ |

## 検証

- [x] 匿名 SaveModal は公開ヒントを表示（`保存すると「みんなの曲」に公開されます。`）
- [x] 所有者ピッカー＋バッジの描画（公開/限定公開/✓下書き、下書き・限定公開バッジ）を一時モックで画面確認（スクショ）
- [x] 匿名視点の公開フィードは不変（24件/72曲、バッジ・メニューなし）
- [x] 型 / lint / vitest 57件、コンソールエラーなし
- ログイン時の insert('draft')／visibility 更新は、#72 で検証済みの RLS＋CHECK に依拠（プレビューでOAuthは通せないため実ログインは未実施）

前提：#72（可視性基盤）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)