### PR TITLE
feat(songs): テンプレにするを先生（is_teacher）限定に

### DIFF
--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -16,6 +16,9 @@ interface Props {
   isOwner: boolean;
   isTemplate: boolean;
   visibility: Visibility;
+  // Whether the viewer (the owner) is a teacher — only teachers may make a
+  // song a template. Unsetting stays open to any owner.
+  isTeacher: boolean;
   t: Translations;
   onDeleted: (id: string) => void;
   onRenamed: (id: string, title: string) => void;
@@ -36,6 +39,7 @@ export function SongCard({
   isOwner,
   isTemplate,
   visibility,
+  isTeacher,
   t,
   onDeleted,
   onRenamed,
@@ -157,9 +161,17 @@ export function SongCard({
                     <div className="song-card-menu-divider" />
                   </>
                 )}
-                <button role="menuitem" onClick={toggleTemplate} disabled={busy}>
-                  {isTemplate ? `★ ${t.templateOff}` : `☆ ${t.templateOn}`}
-                </button>
+                {isTemplate ? (
+                  <button role="menuitem" onClick={toggleTemplate} disabled={busy}>
+                    ★ {t.templateOff}
+                  </button>
+                ) : isTeacher && visibility === "public" ? (
+                  // Only teachers can make a template, and only from a public
+                  // song (templates must be public — see the DB check).
+                  <button role="menuitem" onClick={toggleTemplate} disabled={busy}>
+                    ☆ {t.templateOn}
+                  </button>
+                ) : null}
                 <button
                   role="menuitem"
                   onClick={() => {

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -233,6 +233,7 @@ export default function SongsPage() {
                   isOwner={!!user && song.user_id === user.id}
                   isTemplate={song.is_template}
                   visibility={song.visibility}
+                  isTeacher={!!profile?.isTeacher}
                   t={t}
                   onDeleted={removeSong}
                   onRenamed={renameSong}

--- a/supabase/migrations/0008_template_teacher_only.sql
+++ b/supabase/migrations/0008_template_teacher_only.sql
@@ -1,0 +1,27 @@
+-- Only teachers may make a song a template. Applied to the BeatBubble project.
+--
+-- Gated by a trigger on the false→true transition (not RLS with_check), so
+-- editing or unsetting an existing template is unaffected — an RLS check on the
+-- resulting row would wrongly block a non-teacher from editing a template they
+-- already own. Unsetting (true→false) and non-template edits pass through.
+
+create or replace function public.songs_enforce_template_teacher()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.is_template and (tg_op = 'INSERT' or not old.is_template) then
+    if not exists (select 1 from public.profiles p where p.id = new.user_id and p.is_teacher) then
+      raise exception 'only teachers can make a song a template';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists songs_enforce_template_teacher on public.songs;
+create trigger songs_enforce_template_teacher
+  before insert or update on public.songs
+  for each row execute function public.songs_enforce_template_teacher();


### PR DESCRIPTION
Closes #74

## 概要

「テンプレにする（is_template=true）」を **先生（profiles.is_teacher）だけ**に制限。

## 設計：トリガーで「false→true 遷移」だけをゲート

RLS の with_check だと「既存テンプレを編集するだけ」でも先生要求になり、非先生所有テンプレが編集不能になる副作用がある。→ **BEFORE INSERT/UPDATE トリガー**で、`is_template` が false→true になる遷移（と INSERT で true）のときだけ作者が先生かを確認して拒否。既存ポリシーは無改変。

**効果**：
- 非先生の「テンプレにする」→ 拒否
- 先生の「テンプレにする」→ 許可
- 「テンプレ解除（true→false）」→ 誰でも可
- 非先生が既存テンプレを編集（rename/visibility）→ 可（遷移でない）

## UI（SongCard）

- 「テンプレにする」は **所有者 かつ 先生 かつ 公開** のときだけ表示（テンプレは公開必須なので下書き/限定公開では出さない＝既存の小バグも同時修正）
- 「テンプレ解除」は現在テンプレの所有者に表示（非先生でも自分のテンプレは解除可）
- page.tsx が viewer の `profile.isTeacher` を渡す

## 検証

- [x] トリガー（ロールバックTx）：非先生ブロック／先生許可／非先生の解除・既存テンプレ編集は可
- [x] ブラウザ（所有者/先生をモック）：先生カード＝「☆ テンプレにする」あり、非先生カード＝なし、テンプレカード＝「★ テンプレ解除」あり（非先生所有でも）
- [x] 型 / lint / vitest 57件

## 補足

- 既存テンプレ3件はそのまま（データ移行なし）
- `is_teacher` は管理者が Supabase で手動付与（本人は自己昇格不可＝既存トリガー）

前提：#61（profiles/is_teacher）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)