### PR TITLE
fix(save): 保存エラーの実原因をログ＋原因別メッセージ

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import type { Song } from "@/core/types";
-import type { Locale } from "@/lib/i18n";
+import type { Locale, Translations } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
 import { supabase } from "@/lib/supabase";
 import {
@@ -11,6 +11,28 @@ import {
   validateSongMeta,
   songWithinSizeLimit,
 } from "@/lib/validation";
+
+// Map a Supabase save error to a message a child can act on. The raw error is
+// also logged (see run) so a recurrence can be diagnosed from the console.
+// - auth/session (expired JWT, RLS uid mismatch) → tell them to re-login
+// - rate limit (429, shared school IP under load) → tell them to wait
+// - size check slipping past the client guard → the too-large message
+function saveErrorMessage(error: unknown, t: Translations): string {
+  const e = (error ?? {}) as { code?: string; message?: string; status?: number };
+  const code = e.code ?? "";
+  const msg = (e.message ?? "").toLowerCase();
+  const status = e.status;
+  if (code === "PGRST301" || code === "42501" || msg.includes("jwt") || status === 401 || status === 403) {
+    return t.saveErrorAuth;
+  }
+  if (status === 429 || msg.includes("rate limit") || msg.includes("too many")) {
+    return t.saveErrorRateLimit;
+  }
+  if (code === "23514" || msg.includes("song_data")) {
+    return t.saveErrorTooLarge;
+  }
+  return t.saveErrorFailed;
+}
 
 interface Props {
   song: Song;
@@ -62,13 +84,15 @@ export function SaveModal({
     try {
       const { error: dbError } = await op();
       if (dbError) {
-        setError(t.saveErrorFailed);
+        console.error("[BeatBubble] save failed:", dbError);
+        setError(saveErrorMessage(dbError, t));
         return;
       }
       onSuccess?.();
       onClose();
-    } catch {
-      setError(t.saveErrorFailed);
+    } catch (err) {
+      console.error("[BeatBubble] save threw:", err);
+      setError(saveErrorMessage(err, t));
     } finally {
       setSaving(false);
     }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -36,6 +36,8 @@ export type Translations = {
   saveErrorBlockedWord: string;
   saveErrorTooLarge: string;
   saveErrorFailed: string;
+  saveErrorAuth: string;
+  saveErrorRateLimit: string;
   overwrite: string;
   saveAsNew: string;
   // Songs page
@@ -135,6 +137,8 @@ export const translations: Record<Locale, Translations> = {
     saveErrorBlockedWord: "That title or name can't be used.",
     saveErrorTooLarge: "This song is too large to save.",
     saveErrorFailed: "Couldn't save. Please try again.",
+    saveErrorAuth: "Your login may have expired. Please log out and log in again.",
+    saveErrorRateLimit: "It's busy right now. Please wait a moment and try again.",
     overwrite: "Update",
     saveAsNew: "Save as new",
     backToCreate: "← Create",
@@ -229,6 +233,8 @@ export const translations: Record<Locale, Translations> = {
     saveErrorBlockedWord: "つかえない ことばが はいっています。",
     saveErrorTooLarge: "きょくが おおきすぎて ほぞんできません。",
     saveErrorFailed: "ほぞんに しっぱいしました。もういちど ためしてね。",
+    saveErrorAuth: "ログインの ゆうこうきげんが きれたかも。一度 ログアウトして、もう一度 ログインしてね。",
+    saveErrorRateLimit: "いま こんざつしています。少し 時間を おいてから もう一度 ためしてね。",
     overwrite: "うわがき保存",
     saveAsNew: "新しく保存",
     backToCreate: "← つくる",


### PR DESCRIPTION
## 背景

児童1名が保存時に失敗し「時間を置いてためして」的な表示が出た件（ネットは正常）。現状コードは**全ての保存失敗を1つの汎用文言に潰し、実エラーも握り潰していた**ため、原因が一切追えなかった。

（アプリ内に「時間を置いて〜」という文言は存在せず＝先生の言い換え、または認証/レート由来のメッセージと推定。ログ上、児童のGoogleログイン・`OAuth state expired`・`token_revoked` を確認。「翌日OK」から一過性の認証/セッション/レート要因が最有力。）

## 変更（client のみ、DB変更なし）

- **実エラーをコンソールに記録**（返却エラー／throw の両経路）→ 再発時に 401/PGRST301・RLS 42501・429・check違反・5xx を即特定
- **`saveErrorMessage()` で原因別メッセージ**：
  - 認証/セッション（JWT失効・RLS uid不一致）→「ログインし直してね」
  - レート制限（429・学校の共有IP集中）→「少し待ってね」
  - サイズ超過がクライアントガードをすり抜けた場合 → 既存の too-large 文言
  - その他 → 従来の汎用
- 認証・レート用の ja/en 文言を追加

## 検証（ブラウザ・fetch傍受で実地）

- [x] 保存POSTを 401/PGRST301 に強制 → 「ログインし直してね」表示＋`[BeatBubble] save failed: {PGRST301...}` をログ
- [x] 429 に強制 → 「少し待ってね」表示
- [x] 成功パス不変・型/lint/vitest 57件

## 効果

次に同じ事が起きたら、児童の画面メッセージ＋コンソールログで**原因が確定**できる。今回の最有力（認証失効）なら、ユーザーに「ログアウト→再ログイン」を促せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)