### PR TITLE
fix(editor): 作業中の曲をページ遷移・リロードで消さない（#77 その1）

### DIFF
--- a/src/hooks/useSong.ts
+++ b/src/hooks/useSong.ts
@@ -1,6 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Song } from "@/core/types";
 import { DEFAULT_SONG, HISTORY_LIMIT } from "@/core/defaults";
+import { migrateSong } from "@/core/legacy";
+
+// The in-progress song is mirrored to sessionStorage so navigating away
+// (e.g. to /songs and back — the editor unmounts) or reloading doesn't blank
+// the grid. Session-scoped on purpose: it dies with the tab, so it can't
+// resurrect a weeks-old draft, and two tabs don't fight over one key.
+const WORK_KEY = "beatbubble-work";
+
+function restoreWork(): Song | null {
+  try {
+    const raw = sessionStorage.getItem(WORK_KEY);
+    // Persisted songs are versioned — always revive through migrateSong so a
+    // deploy that bumps the model doesn't break a tab that was already open.
+    if (raw) return migrateSong(JSON.parse(raw));
+  } catch {
+    // Corrupt/unreadable stored work — fall back to a fresh song.
+  }
+  return null;
+}
 
 // Owns the song document plus its undo history.
 // songRef mirrors the latest song for callers that read it outside React
@@ -10,8 +29,33 @@ export function useSong() {
   const [history, setHistory] = useState<Song[]>([]);
   const songRef = useRef<Song>(song);
 
+  // Restore after mount (not in the useState initializer) so the first client
+  // render matches the server-rendered empty grid — no hydration mismatch. A
+  // ?load= fetch resolving later still wins by replacing the song.
+  useEffect(() => {
+    let active = true;
+    async function restore() {
+      const saved = restoreWork();
+      if (active && saved) setSong(saved);
+    }
+    restore();
+    return () => {
+      active = false;
+    };
+  }, []);
+
   useEffect(() => {
     songRef.current = song;
+    // Never persist the pristine default (reference check): the mount render
+    // holds DEFAULT_SONG itself, and writing it here would clobber the stored
+    // work before/between the restore effect's runs (StrictMode re-runs
+    // effects). Any real edit/load produces a new object, which persists.
+    if (song === DEFAULT_SONG) return;
+    try {
+      sessionStorage.setItem(WORK_KEY, JSON.stringify(song));
+    } catch {
+      // Storage full/unavailable — persistence is best-effort.
+    }
   }, [song]);
 
   const pushHistory = useCallback((snapshot: Song) => {
@@ -27,6 +71,13 @@ export function useSong() {
   const reset = useCallback(() => {
     setSong(DEFAULT_SONG);
     setHistory([]);
+    // The persist effect skips DEFAULT_SONG, so drop the stored work here —
+    // otherwise navigating away and back would resurrect the pre-reset song.
+    try {
+      sessionStorage.removeItem(WORK_KEY);
+    } catch {
+      // Storage unavailable — nothing to clear.
+    }
   }, []);
 
   return {

--- a/src/hooks/useSong.ts
+++ b/src/hooks/useSong.ts
@@ -7,9 +7,11 @@ import { migrateSong } from "@/core/legacy";
 // (e.g. to /songs and back — the editor unmounts) or reloading doesn't blank
 // the grid. Session-scoped on purpose: it dies with the tab, so it can't
 // resurrect a weeks-old draft, and two tabs don't fight over one key.
+// All storage access goes through these helpers — each swallows its own
+// failure, so the hook body stays free of try/catch.
 const WORK_KEY = "beatbubble-work";
 
-function restoreWork(): Song | null {
+function readStoredWork(): Song | null {
   try {
     const raw = sessionStorage.getItem(WORK_KEY);
     // Persisted songs are versioned — always revive through migrateSong so a
@@ -19,6 +21,22 @@ function restoreWork(): Song | null {
     // Corrupt/unreadable stored work — fall back to a fresh song.
   }
   return null;
+}
+
+function writeStoredWork(song: Song): void {
+  try {
+    sessionStorage.setItem(WORK_KEY, JSON.stringify(song));
+  } catch {
+    // Storage full/unavailable — persistence is best-effort.
+  }
+}
+
+function clearStoredWork(): void {
+  try {
+    sessionStorage.removeItem(WORK_KEY);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
 }
 
 // Owns the song document plus its undo history.
@@ -35,7 +53,7 @@ export function useSong() {
   useEffect(() => {
     let active = true;
     async function restore() {
-      const saved = restoreWork();
+      const saved = readStoredWork();
       if (active && saved) setSong(saved);
     }
     restore();
@@ -50,12 +68,7 @@ export function useSong() {
     // holds DEFAULT_SONG itself, and writing it here would clobber the stored
     // work before/between the restore effect's runs (StrictMode re-runs
     // effects). Any real edit/load produces a new object, which persists.
-    if (song === DEFAULT_SONG) return;
-    try {
-      sessionStorage.setItem(WORK_KEY, JSON.stringify(song));
-    } catch {
-      // Storage full/unavailable — persistence is best-effort.
-    }
+    if (song !== DEFAULT_SONG) writeStoredWork(song);
   }, [song]);
 
   const pushHistory = useCallback((snapshot: Song) => {
@@ -73,11 +86,7 @@ export function useSong() {
     setHistory([]);
     // The persist effect skips DEFAULT_SONG, so drop the stored work here —
     // otherwise navigating away and back would resurrect the pre-reset song.
-    try {
-      sessionStorage.removeItem(WORK_KEY);
-    } catch {
-      // Storage unavailable — nothing to clear.
-    }
+    clearStoredWork();
   }, []);
 
   return {


### PR DESCRIPTION
#77 の修正その1（A）。

## 背景

エディタの曲はReact stateのみだったため、「みんなの曲」へ移動して戻る（またはリロード）とグリッドが真っ白になっていた。下書き既定化以前は公開フィードから開き直せたため表面化しなかったが、下書き化でその回復経路が消え、「保存したのに全部消えた」騒ぎ（児童4人）の主犯に。

## 変更

- 作業中の曲を **sessionStorage にミラー**し、マウント後に復元（タブと共に消えるスコープ＝古い曲の亡霊やタブ間衝突なし）
- 復元は useState 初期化子でなく**マウントeffect**（SSRの空グリッドとの hydration 不整合を回避）。`?load=` は従来どおり復元より優先
- **素の DEFAULT_SONG は永続化しない**（参照比較）— StrictMode の二重実行で永続化が復元を上書きする競合を検証中に実際に検出し、この方式で解消。リセット時は明示的に storage をクリア（戻る操作でリセット前の曲が蘇らないように）
- 復元は versioned-song 規約どおり `migrateSong()` 経由

## 検証（ブラウザ実操作）

- [x] ノート配置 → /songs → 戻る：**生存**（修正前は消失）
- [x] リロード：生存
- [x] リセット：グリッド・storage ともクリア
- [x] `?load=` リンク：復元済み作業を上書きしてロード＋URLクリーン
- [x] 型 / lint / vitest 57件、コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)