### PR TITLE
feat(save): 保存時に「下書きほぞん／公開してほぞん」を選ぶ（#77 その2）

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -61,6 +61,9 @@ export function SaveModal({
   const [author, setAuthor] = useState(existing ? existing.author : defaultAuthor);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // After a successful new save, show a confirmation telling the child what
+  // happened and where the song went, instead of silently closing.
+  const [savedAs, setSavedAs] = useState<"draft" | "public" | null>(null);
 
   const guard = (): boolean => {
     const meta = validateSongMeta({ title, author });
@@ -77,7 +80,7 @@ export function SaveModal({
     return true;
   };
 
-  const run = async (op: () => Promise<{ error: unknown }>, onSuccess?: () => void) => {
+  const run = async (op: () => Promise<{ error: unknown }>, onSuccess: () => void) => {
     if (!guard()) return;
     setSaving(true);
     setError(null);
@@ -88,8 +91,7 @@ export function SaveModal({
         setError(saveErrorMessage(dbError, t));
         return;
       }
-      onSuccess?.();
-      onClose();
+      onSuccess();
     } catch (err) {
       console.error("[BeatBubble] save threw:", err);
       setError(saveErrorMessage(err, t));
@@ -98,17 +100,20 @@ export function SaveModal({
     }
   };
 
-  const handleInsert = () =>
-    run(async () =>
-      supabase.from("songs").insert({
-        title: title.trim(),
-        author: author.trim(),
-        song_data: song,
-        user_id: userId,
-        // Signed-in saves start private (publish later); anonymous saves have
-        // no owner to manage a draft, so they go straight to public.
-        visibility: userId ? "draft" : "public",
-      })
+  // New saves pick their visibility explicitly (the child chooses; nothing is
+  // decided silently). Anonymous saves are always public — there is no owner
+  // to manage a draft.
+  const handleInsert = (visibility: "draft" | "public") =>
+    run(
+      async () =>
+        supabase.from("songs").insert({
+          title: title.trim(),
+          author: author.trim(),
+          song_data: song,
+          user_id: userId,
+          visibility,
+        }),
+      () => setSavedAs(visibility)
     );
 
   const handleOverwrite = () =>
@@ -118,10 +123,31 @@ export function SaveModal({
           .from("songs")
           .update({ title: title.trim(), author: author.trim(), song_data: song })
           .eq("id", existing!.id),
-      () => onOverwritten?.(title.trim(), author.trim())
+      () => {
+        onOverwritten?.(title.trim(), author.trim());
+        onClose();
+      }
     );
 
   const canSave = !saving && !!title.trim() && !!author.trim();
+
+  // Post-save confirmation: say what happened and where the song went.
+  if (savedAs) {
+    return (
+      <div className="modal-overlay" onClick={onClose}>
+        <div className="modal" onClick={(e) => e.stopPropagation()}>
+          <h2 className="modal-title">
+            {savedAs === "draft" ? t.savedDraftMsg : t.savedPublicMsg}
+          </h2>
+          <div className="modal-actions">
+            <button className="modal-save" onClick={onClose} autoFocus>
+              {t.close}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -151,7 +177,7 @@ export function SaveModal({
           />
         </div>
         {!existing && (
-          <p className="modal-hint">{userId ? t.saveDraftHint : t.savePublicHint}</p>
+          <p className="modal-hint">{userId ? t.saveChoiceHint : t.savePublicHint}</p>
         )}
         {error && <p className="modal-error">{error}</p>}
         <div className="modal-actions">
@@ -160,15 +186,42 @@ export function SaveModal({
           </button>
           {existing ? (
             <>
-              <button className="modal-cancel" onClick={handleInsert} disabled={!canSave}>
+              <button
+                className="modal-cancel"
+                onClick={() => handleInsert("draft")}
+                disabled={!canSave}
+              >
                 {t.saveAsNew}
               </button>
               <button className="modal-save" onClick={handleOverwrite} disabled={!canSave}>
                 {saving ? t.saving : t.overwrite}
               </button>
             </>
+          ) : userId ? (
+            // Signed in: the child picks the visibility — draft (primary,
+            // safe default) or publish right away. Nothing decided silently.
+            <>
+              <button
+                className="modal-cancel"
+                onClick={() => handleInsert("public")}
+                disabled={!canSave}
+              >
+                {t.savePublicBtn}
+              </button>
+              <button
+                className="modal-save"
+                onClick={() => handleInsert("draft")}
+                disabled={!canSave}
+              >
+                {saving ? t.saving : t.saveDraftBtn}
+              </button>
+            </>
           ) : (
-            <button className="modal-save" onClick={handleInsert} disabled={!canSave}>
+            <button
+              className="modal-save"
+              onClick={() => handleInsert("public")}
+              disabled={!canSave}
+            >
               {saving ? t.saving : t.save}
             </button>
           )}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -69,8 +69,13 @@ export type Translations = {
   visUnlisted: string;
   visDraft: string;
   visibilityLabel: string;
-  saveDraftHint: string;
+  saveChoiceHint: string;
   savePublicHint: string;
+  saveDraftBtn: string;
+  savePublicBtn: string;
+  savedDraftMsg: string;
+  savedPublicMsg: string;
+  close: string;
   rename: string;
   deleteSong: string;
   confirmDeleteSong: string;
@@ -169,8 +174,13 @@ export const translations: Record<Locale, Translations> = {
     visUnlisted: "Unlisted",
     visDraft: "Draft",
     visibilityLabel: "Visibility",
-    saveDraftHint: "Saved as a draft. You can publish it later from Everyone's Songs.",
+    saveChoiceHint: "A draft can be published anytime later.",
     savePublicHint: "This will be published to Everyone's Songs.",
+    saveDraftBtn: "Save as draft",
+    savePublicBtn: "Save & publish",
+    savedDraftMsg: "Saved as a draft! Find it under \"Mine\" in Everyone's Songs.",
+    savedPublicMsg: "Published to Everyone's Songs!",
+    close: "Close",
     rename: "Rename",
     deleteSong: "Delete",
     confirmDeleteSong: "Delete this song?",
@@ -265,8 +275,13 @@ export const translations: Record<Locale, Translations> = {
     visUnlisted: "限定公開",
     visDraft: "下書き",
     visibilityLabel: "公開はんい",
-    saveDraftHint: "下書きとして保存します。あとで「みんなの曲」で公開できます。",
+    saveChoiceHint: "下書きは あとから いつでも 公開できるよ。",
     savePublicHint: "保存すると「みんなの曲」に公開されます。",
+    saveDraftBtn: "下書きほぞん",
+    savePublicBtn: "公開してほぞん",
+    savedDraftMsg: "下書きに ほぞんしたよ！「みんなの曲」の「じぶん」から 見られるよ。",
+    savedPublicMsg: "「みんなの曲」に 公開したよ！",
+    close: "とじる",
     rename: "なまえをかえる",
     deleteSong: "けす",
     confirmDeleteSong: "この曲を けしますか？",


### PR DESCRIPTION
#77 の修正その2（B'）。

## 背景

下書き既定化で**可視性がシステムに黙って決まる**ため、児童は「ほぞん＝みんなの曲に出る」の習慣のまま「ない！消えた！」に。意思決定の瞬間に選択肢を見せる方式へ。

## 変更

- **ログインの新規保存**：ボタンを2つに — **下書きほぞん**（主・安全側）／**公開してほぞん**。黙って決まる状態を廃止
- **保存完了ビュー**：無言で閉じず、何が起きたかを明示 —「下書きに ほぞんしたよ！『みんなの曲』の『じぶん』から 見られるよ。」／「『みんなの曲』に 公開したよ！」＋とじる
- **匿名**：従来どおり「ほぞん」1つ（公開のみ・ヒント維持）
- **上書き**：可視性不変・従来どおり即クローズ。上書きモードの「新しく保存」は下書きで保存
- **限定公開**：モーダルには出さない（子どもには2択）。カードの可視性ピッカーで従来どおり

## 検証（POSTは傍受・本番へ書き込みなし）

- [x] 匿名：1ボタン＋公開ヒント → `visibility=public, user_id=null` → 公開完了メッセージ → とじる
- [x] ログイン（モックid）：2ボタン表示 → 下書きほぞん=`visibility=draft`／公開してほぞん=`visibility=public`、それぞれの完了メッセージ（スクショあり）
- [x] 型 / lint / vitest 57件

関連：#78（その1・エディタ状態保持）。残り：C（`?load=`失敗時メッセージ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)