### PR TITLE
fix(load): ?load= が開けないときに通知を出す（#77 その3）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,6 +55,7 @@ export default function Home() {
   const [isConfirmingReset, setIsConfirmingReset] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [isLockMode, setIsLockMode] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   // The song loaded via ?load=<id>, so its owner can overwrite it on save.
@@ -92,7 +93,7 @@ export default function Home() {
       .select("id, title, author, song_data, user_id, is_template")
       .eq("id", loadId)
       .single()
-      .then(({ data }) => {
+      .then(({ data, error }) => {
         if (data?.song_data) {
           setSong(migrateSong(data.song_data));
           setLoadedSong({
@@ -103,6 +104,13 @@ export default function Home() {
             isTemplate: data.is_template ?? false,
           });
           window.history.replaceState({}, "", "/");
+        } else {
+          // Not found or not readable (e.g. someone else's draft, or the
+          // session isn't restored yet). Say so instead of silently showing
+          // an empty grid, and keep ?load in the URL so reloading after a
+          // login retries the fetch.
+          console.error("[BeatBubble] load failed:", error);
+          setLoadFailed(true);
         }
       });
   }, [setSong]);
@@ -352,6 +360,19 @@ export default function Home() {
         onSignOut={signOut}
         onOpenProfile={() => setIsProfileModalOpen(true)}
       />
+
+      {loadFailed && (
+        <div className="editor-notice" role="alert">
+          <span>{t.loadFailed}</span>
+          <button
+            className="editor-notice-close"
+            onClick={() => setLoadFailed(false)}
+            aria-label={t.close}
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {isSettingsOpen && (
         <SettingsPanel

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -70,3 +70,37 @@ a[href],
 .dragging {
   user-select: none;
 }
+
+/* Editor notice bar (e.g. a ?load= that couldn't be opened) */
+.editor-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 12px 16px 0;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1.5px solid #ee5253;
+  background: rgba(238, 82, 83, 0.1);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.editor-notice-close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.editor-notice-close:hover {
+  opacity: 1;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -76,6 +76,7 @@ export type Translations = {
   savedDraftMsg: string;
   savedPublicMsg: string;
   close: string;
+  loadFailed: string;
   rename: string;
   deleteSong: string;
   confirmDeleteSong: string;
@@ -181,6 +182,7 @@ export const translations: Record<Locale, Translations> = {
     savedDraftMsg: "Saved as a draft! Find it under \"Mine\" in Everyone's Songs.",
     savedPublicMsg: "Published to Everyone's Songs!",
     close: "Close",
+    loadFailed: "Couldn't open this song. Check that you're logged in, then reload to try again.",
     rename: "Rename",
     deleteSong: "Delete",
     confirmDeleteSong: "Delete this song?",
@@ -282,6 +284,7 @@ export const translations: Record<Locale, Translations> = {
     savedDraftMsg: "下書きに ほぞんしたよ！「みんなの曲」の「じぶん」から 見られるよ。",
     savedPublicMsg: "「みんなの曲」に 公開したよ！",
     close: "とじる",
+    loadFailed: "この曲を ひらけなかったよ。ログインしているか たしかめて、ページを さいよみこみ してみてね。",
     rename: "なまえをかえる",
     deleteSong: "けす",
     confirmDeleteSong: "この曲を けしますか？",


### PR DESCRIPTION
#77 の修正その3（C）。**#79 の上に積んでいます（base: feat/save-visibility-choice）— #79 を先にマージしてから、このPRのbaseをmainに変えてマージしてください。**

## 背景

`?load=` の読み込み失敗（他人の下書き・削除済み・未認証でRLS拒否）が**無言**で、空のグリッドだけが表示され「曲が消えた」に見えていた。

## 変更

- 失敗時に**赤い通知バー**を表示（「この曲を ひらけなかったよ。ログインしているか たしかめて、ページを さいよみこみ してみてね。」）＋実エラーをコンソールへ
- 失敗時は **URLの `?load=` を保持**（ログイン後のリロードで再試行できる）。成功時は従来どおりURLクリーン
- ×で閉じられる（role=alert）

## 検証

- [x] 存在しないID → 通知表示・URL保持・×で消える
- [x] 正常なID → 25ノート読込・通知なし・URLクリーン
- [x] 型 / lint / vitest 57件

🤖 Generated with [Claude Code](https://claude.com/claude-code)