### PR TITLE
feat(save): 未ログイン保存に「あとで自分で消せない」警告を出す

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -176,9 +176,14 @@ export function SaveModal({
             maxLength={MAX_AUTHOR_LENGTH}
           />
         </div>
-        {!existing && (
-          <p className="modal-hint">{userId ? t.saveChoiceHint : t.savePublicHint}</p>
-        )}
+        {!existing &&
+          (userId ? (
+            <p className="modal-hint">{t.saveChoiceHint}</p>
+          ) : (
+            // Not signed in: an anonymous save has no owner, so the child can't
+            // delete it later. Warn prominently before they publish.
+            <p className="modal-warn">{t.saveAnonWarn}</p>
+          ))}
         {error && <p className="modal-error">{error}</p>}
         <div className="modal-actions">
           <button className="modal-cancel" onClick={onClose}>

--- a/src/app/styles/modal.css
+++ b/src/app/styles/modal.css
@@ -118,6 +118,19 @@ select.modal-input {
   line-height: 1.5;
 }
 
+/* Prominent warning (e.g. anonymous save can't be deleted later). */
+.modal-warn {
+  margin: -4px 0 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1.5px solid #ef9f27;
+  background: rgba(239, 159, 39, 0.12);
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
 .modal-save {
   padding: 8px 20px;
   border-radius: 12px;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -70,7 +70,7 @@ export type Translations = {
   visDraft: string;
   visibilityLabel: string;
   saveChoiceHint: string;
-  savePublicHint: string;
+  saveAnonWarn: string;
   saveDraftBtn: string;
   savePublicBtn: string;
   savedDraftMsg: string;
@@ -176,7 +176,7 @@ export const translations: Record<Locale, Translations> = {
     visDraft: "Draft",
     visibilityLabel: "Visibility",
     saveChoiceHint: "A draft can be published anytime later.",
-    savePublicHint: "This will be published to Everyone's Songs.",
+    saveAnonWarn: "You're not logged in. If you save now it goes public and you won't be able to delete it yourself later.",
     saveDraftBtn: "Save as draft",
     savePublicBtn: "Save & publish",
     savedDraftMsg: "Saved as a draft! Find it under \"Mine\" in Everyone's Songs.",
@@ -278,7 +278,7 @@ export const translations: Record<Locale, Translations> = {
     visDraft: "下書き",
     visibilityLabel: "公開はんい",
     saveChoiceHint: "下書きは あとから いつでも 公開できるよ。",
-    savePublicHint: "保存すると「みんなの曲」に公開されます。",
+    saveAnonWarn: "ログインしていないよ。このまま ほぞんすると「みんなの曲」に こうかいされて、あとで じぶんで けせなくなるよ。",
     saveDraftBtn: "下書きほぞん",
     savePublicBtn: "公開してほぞん",
     savedDraftMsg: "下書きに ほぞんしたよ！「みんなの曲」の「じぶん」から 見られるよ。",


### PR DESCRIPTION
## 背景

寺島弦吾さんが「うんこ」を**未ログインのまま公開保存**していた。author に名前は入っているが `user_id=null`（匿名）のため、
- 「じぶんの曲」に出ない（じぶんタブは `user_id=自分` のみ）
- 削除はRLSで所有者のみ許可 → **本人を含め誰も消せない**

匿名保存自体は維持しつつ（案2）、保存前に警告を出す。

## 変更

- 未ログインの保存モーダルの控えめヒントを、**目立つオレンジ警告**に変更：「ログインしていないよ。このまま ほぞんすると『みんなの曲』に こうかいされて、あとで じぶんで けせなくなるよ。」
- ログイン時は従来の下書きヒントのまま
- `savePublicHint` → `saveAnonWarn` にリネーム（この分岐でのみ使用）＋ `.modal-warn` スタイル追加

## 検証

- [x] 未ログイン保存モーダルにオレンジ警告表示（スクショ）／ログイン時は通常ヒント
- [x] 型 / lint / vitest 57件

## 補足（別対応）

今回の「うんこ」（匿名・持ち主なし・428ノート）は所有者がいないためUIから消せない。削除は管理側で対応要（別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)