### PR TITLE
feat(grid): 再生中に譜面が再生ヘッドに追従してスクロール

### DIFF
--- a/src/app/components/Grid.tsx
+++ b/src/app/components/Grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import type { RefObject } from "react";
 import type { DrumId, MelodyNote, NoteName, Song } from "@/core/types";
 import type { Locale } from "@/lib/i18n";
@@ -36,6 +37,37 @@ export function Grid({
 }: Props) {
   const noteRows = buildNoteRows(song);
   const stepsArray = Array.from({ length: totalSteps(song) }, (_, i) => i);
+
+  // Follow the playhead during playback: once it advances past an anchor
+  // (~40% across the usable width), scroll the grid so the highlighted column
+  // stays put and the sheet flows underneath it — like a scrolling score. The
+  // start of the song stays visible until the playhead reaches the anchor.
+  useEffect(() => {
+    if (playheadStep == null) return;
+    const container = gridContainerRef.current;
+    const grid = gridRef.current;
+    // Nothing to follow if the whole song already fits in view.
+    if (!container || !grid || container.scrollWidth <= container.clientWidth) return;
+    const cell = grid.querySelector<HTMLElement>(".cell.playhead");
+    if (!cell) return;
+
+    // The label column is sticky at the left, so the usable area starts past it.
+    const labels = container.querySelector<HTMLElement>(".labels");
+    const inset = (labels?.offsetWidth ?? 0) + 8; // label width + gap
+    const view = container.clientWidth;
+    const cellLeft = cell.getBoundingClientRect().left - container.getBoundingClientRect().left;
+    const anchor = inset + (view - inset) * 0.4;
+
+    // Scroll instantly (not CSS smooth): the per-step nudge is ~one cell, so
+    // stepping it in sync with the beat reads as the sheet flowing under a
+    // fixed playhead — and it works everywhere (some webviews ignore
+    // behavior:"smooth").
+    if (playheadStep === 0) {
+      container.scrollLeft = 0; // loop restart → back to the start
+    } else if (cellLeft > anchor) {
+      container.scrollLeft += cellLeft - anchor;
+    }
+  }, [playheadStep, gridContainerRef, gridRef]);
 
   const renderBubble = (note: MelodyNote, step: number) => {
     const position = getNotePosition(note, step);


### PR DESCRIPTION
## 概要

再生をした際に、譜面が再生ヘッドに追従してスクロールするようにしました（先生からの要望、#83）。「譜面が固定された再生ヘッドの下を流れる」形（案A）です。

グリッドが横に長い（ブロック数が多い / 画面が狭い）と、これまで再生ヘッドが画面外へ出て演奏位置を見失っていました。これで演奏中の列が常に見えます。

## 挙動

- 再生ヘッドがビュー内のアンカー位置（横 ~40%、左端の固定ラベル列ぶんを除いた使用領域基準）に達するまでは、曲の頭出しが見えたまま（スクロールしない）
- アンカー到達後は再生ヘッドをその位置に留め、譜面を左へスクロール
- ループ折り返し（`playheadStep === 0`）で先頭に戻る
- 曲がビュー内に収まる場合は何もしない（`scrollWidth <= clientWidth`）

## 実装

- `src/app/components/Grid.tsx` に `playheadStep` 依存の `useEffect` を追加（表示のみ）
- スクロールは CSS smooth ではなく即時（`scrollLeft +=`）：1ステップ移動が約1セルなのでビート同期で「流れる」ように見え、`behavior:"smooth"` を無視する webview でも確実に動作
- `src/core` / データモデル / 音声スケジューリングへの影響なし

## 検証

- `tsc --noEmit` クリーン / `pnpm lint` クリーン / vitest 57 passed
- プレビュー（480×800 で横スクロール発生させて確認）:
  - 再生中 `scrollLeft` が 0→90→210→…→2184 と前進、再生ヘッドはアンカー(≈207px)に固定
  - ループ折り返しで `scrollLeft` が 0 にリセットし再前進
  - 再生ヘッドは常にビュー内に維持
- 900px 幅でも目視確認（スクリーンショット取得済み）

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)