### PR TITLE
feat(grid): 譜面用の太い常時表示スクロールバーを追加

### DIFF
--- a/src/app/components/Grid.tsx
+++ b/src/app/components/Grid.tsx
@@ -8,6 +8,7 @@ import { totalSteps } from "@/core/utils";
 import { colorForDrum, colorForNote } from "@/ui/color";
 import { noteLabel } from "@/ui/noteLabel";
 import { buildNoteRows, findMelodyNoteAt, getNotePosition } from "@/ui/grid";
+import { GridScrollbar } from "./GridScrollbar";
 
 const DRUM_ROWS: DrumId[] = ["hihat", "snare", "kick"];
 
@@ -36,7 +37,8 @@ export function Grid({
   getDrumCellHandlers,
 }: Props) {
   const noteRows = buildNoteRows(song);
-  const stepsArray = Array.from({ length: totalSteps(song) }, (_, i) => i);
+  const steps = totalSteps(song);
+  const stepsArray = Array.from({ length: steps }, (_, i) => i);
 
   // Follow the playhead during playback: once it advances past an anchor
   // (~40% across the usable width), scroll the grid so the highlighted column
@@ -135,7 +137,7 @@ export function Grid({
 
   return (
     <main className="main">
-      <div className="grid-container" ref={gridContainerRef}>
+      <div className="grid-container" id="grid-scroll-area" ref={gridContainerRef}>
         <div className="labels grid">
           {noteRows.map((noteName) => (
             <div key={noteName} className="label-row">
@@ -165,6 +167,11 @@ export function Grid({
           ))}
         </div>
       </div>
+      <GridScrollbar
+        containerRef={gridContainerRef}
+        controlsId="grid-scroll-area"
+        totalSteps={steps}
+      />
     </main>
   );
 }

--- a/src/app/components/GridScrollbar.tsx
+++ b/src/app/components/GridScrollbar.tsx
@@ -92,6 +92,14 @@ export function GridScrollbar({ containerRef, controlsId, totalSteps }: Props) {
     measure();
   }, [totalSteps, measure]);
 
+  // Scroll the container to x (clamped in range) and sync the thumb at once.
+  const scrollContainerTo = (x: number) => {
+    const c = containerRef.current;
+    if (!c) return;
+    c.scrollLeft = Math.max(0, Math.min(c.scrollWidth - c.clientWidth, x));
+    measure();
+  };
+
   const onThumbPointerDown = (e: React.PointerEvent) => {
     const c = containerRef.current;
     const track = trackRef.current;
@@ -113,13 +121,10 @@ export function GridScrollbar({ containerRef, controlsId, totalSteps }: Props) {
 
   const onThumbPointerMove = (e: React.PointerEvent) => {
     const d = dragRef.current;
-    const c = containerRef.current;
-    if (!d || !c || d.range <= 0) return;
-    const scrollDelta = ((e.clientX - d.startX) / d.range) * d.maxScroll;
-    c.scrollLeft = Math.max(0, Math.min(d.maxScroll, d.startScroll + scrollDelta));
-    // Reflect it on the thumb right away — glued to the finger, without waiting
-    // on the (rAF-throttled) scroll listener.
-    measure();
+    if (!d || d.range <= 0) return;
+    // scrollContainerTo re-syncs the thumb right away — glued to the finger,
+    // without waiting on the (rAF-throttled) scroll listener.
+    scrollContainerTo(d.startScroll + ((e.clientX - d.startX) / d.range) * d.maxScroll);
   };
 
   const onThumbPointerUp = (e: React.PointerEvent) => {
@@ -136,13 +141,10 @@ export function GridScrollbar({ containerRef, controlsId, totalSteps }: Props) {
     const c = containerRef.current;
     const track = trackRef.current;
     if (!c || !track || !thumb.draggable) return;
-    const rect = track.getBoundingClientRect();
-    const target = e.clientX - rect.left - thumb.width / 2;
     const range = track.clientWidth - thumb.width;
-    const maxScroll = c.scrollWidth - c.clientWidth;
     if (range <= 0) return;
-    c.scrollLeft = Math.max(0, Math.min(maxScroll, (target / range) * maxScroll));
-    measure();
+    const target = e.clientX - track.getBoundingClientRect().left - thumb.width / 2;
+    scrollContainerTo((target / range) * (c.scrollWidth - c.clientWidth));
   };
 
   return (

--- a/src/app/components/GridScrollbar.tsx
+++ b/src/app/components/GridScrollbar.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+// Keep the thumb a grabbable size even when the song is very long and the
+// proportional width would otherwise shrink to a sliver.
+const MIN_THUMB = 48;
+
+interface Props {
+  // The horizontal scroller (`.grid-container`) whose position this bar mirrors.
+  containerRef: RefObject<HTMLDivElement | null>;
+  // id of the scroller, for the scrollbar's aria-controls.
+  controlsId: string;
+  // Re-measure when the grid length changes (blocks ±). The container's own
+  // size is unchanged then, so a ResizeObserver on it wouldn't fire.
+  totalSteps: number;
+}
+
+interface Thumb {
+  width: number;
+  left: number;
+  // False when the whole song already fits (nothing to drag).
+  draggable: boolean;
+  // Scroll position as a 0–100 percentage, for aria-valuenow.
+  value: number;
+}
+
+// An always-visible, chunky, one-finger-draggable horizontal scrollbar for the
+// grid. The native bar is thin, auto-hiding on tablets, and can't be thickened
+// on iPad Safari, so we render our own and hide the native one (see grid.css).
+// It only reads/writes `container.scrollLeft`, so it stays in sync with every
+// other scroll source (two-finger drag, playhead-follow during playback).
+export function GridScrollbar({ containerRef, controlsId, totalSteps }: Props) {
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const [thumb, setThumb] = useState<Thumb>({ width: 0, left: 0, draggable: false, value: 0 });
+  const dragRef = useRef<{ startX: number; startScroll: number; maxScroll: number; range: number } | null>(
+    null
+  );
+  const rafRef = useRef(0);
+
+  const measure = useCallback(() => {
+    const c = containerRef.current;
+    const track = trackRef.current;
+    if (!c || !track) return;
+    const { scrollWidth, clientWidth, scrollLeft } = c;
+    const trackWidth = track.clientWidth;
+    // Thumb length is proportional to how much of the song is on screen,
+    // clamped so it never gets smaller than a fingertip nor wider than the track.
+    const width = Math.min(
+      trackWidth,
+      Math.max(MIN_THUMB, Math.round((clientWidth / scrollWidth) * trackWidth))
+    );
+    const maxScroll = scrollWidth - clientWidth;
+    const range = trackWidth - width;
+    const draggable = maxScroll > 1 && range > 1;
+    const left = draggable ? Math.round((scrollLeft / maxScroll) * range) : 0;
+    const value = maxScroll > 0 ? Math.round((scrollLeft / maxScroll) * 100) : 0;
+    setThumb((prev) =>
+      prev.width === width && prev.left === left && prev.draggable === draggable && prev.value === value
+        ? prev
+        : { width, left, draggable, value }
+    );
+  }, [containerRef]);
+
+  // Reading layout in a scroll handler can thrash; batch to one read per frame.
+  const scheduleMeasure = useCallback(() => {
+    if (rafRef.current) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = 0;
+      measure();
+    });
+  }, [measure]);
+
+  useEffect(() => {
+    const c = containerRef.current;
+    if (!c) return;
+    measure();
+    c.addEventListener("scroll", scheduleMeasure, { passive: true });
+    const ro = new ResizeObserver(scheduleMeasure);
+    ro.observe(c);
+    return () => {
+      c.removeEventListener("scroll", scheduleMeasure);
+      ro.disconnect();
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [containerRef, measure, scheduleMeasure]);
+
+  // Grid grew/shrank (blocks changed): the container size is unchanged, so the
+  // ResizeObserver above won't catch it — re-measure on the step count.
+  useEffect(() => {
+    measure();
+  }, [totalSteps, measure]);
+
+  const onThumbPointerDown = (e: React.PointerEvent) => {
+    const c = containerRef.current;
+    const track = trackRef.current;
+    if (!c || !track || !thumb.draggable) return;
+    e.preventDefault();
+    e.stopPropagation(); // don't also trigger the track's page-jump
+    // Capture so the drag keeps tracking when the finger leaves the thumb.
+    // Can throw InvalidStateError if the pointer is already gone — ignore.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {}
+    dragRef.current = {
+      startX: e.clientX,
+      startScroll: c.scrollLeft,
+      maxScroll: c.scrollWidth - c.clientWidth,
+      range: track.clientWidth - thumb.width,
+    };
+  };
+
+  const onThumbPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    const c = containerRef.current;
+    if (!d || !c || d.range <= 0) return;
+    const scrollDelta = ((e.clientX - d.startX) / d.range) * d.maxScroll;
+    c.scrollLeft = Math.max(0, Math.min(d.maxScroll, d.startScroll + scrollDelta));
+    // Reflect it on the thumb right away — glued to the finger, without waiting
+    // on the (rAF-throttled) scroll listener.
+    measure();
+  };
+
+  const onThumbPointerUp = (e: React.PointerEvent) => {
+    if (!dragRef.current) return;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {}
+    dragRef.current = null;
+  };
+
+  // Tapping the empty part of the track jumps toward that spot (centres the
+  // thumb under the tap), so kids can move a long way without dragging.
+  const onTrackPointerDown = (e: React.PointerEvent) => {
+    const c = containerRef.current;
+    const track = trackRef.current;
+    if (!c || !track || !thumb.draggable) return;
+    const rect = track.getBoundingClientRect();
+    const target = e.clientX - rect.left - thumb.width / 2;
+    const range = track.clientWidth - thumb.width;
+    const maxScroll = c.scrollWidth - c.clientWidth;
+    if (range <= 0) return;
+    c.scrollLeft = Math.max(0, Math.min(maxScroll, (target / range) * maxScroll));
+    measure();
+  };
+
+  return (
+    <div
+      className="grid-scrollbar"
+      ref={trackRef}
+      onPointerDown={onTrackPointerDown}
+      role="scrollbar"
+      aria-orientation="horizontal"
+      aria-label="楽譜を横にスクロール"
+      aria-controls={controlsId}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={thumb.value}
+    >
+      <div
+        className={`grid-scrollbar-thumb ${thumb.draggable ? "" : "grid-scrollbar-thumb--full"}`}
+        style={{ width: thumb.width, transform: `translateX(${thumb.left}px)` }}
+        onPointerDown={onThumbPointerDown}
+        onPointerMove={onThumbPointerMove}
+        onPointerUp={onThumbPointerUp}
+        onPointerCancel={onThumbPointerUp}
+      />
+    </div>
+  );
+}

--- a/src/app/styles/grid.css
+++ b/src/app/styles/grid.css
@@ -11,6 +11,70 @@
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 8px;
+  /* Hide the native bar — we render our own always-visible one (.grid-scrollbar)
+     because the native bar is thin, auto-hiding on tablets, and can't be
+     thickened on iPad Safari. Scrolling itself stays enabled. */
+  scrollbar-width: none; /* Firefox */
+}
+
+.grid-container::-webkit-scrollbar {
+  display: none; /* Chrome/Safari/Edge */
+}
+
+/* Custom horizontal scrollbar: always visible, chunky, one-finger draggable.
+   Kids slide the thumb (or tap the track) to move a long sheet — no two-finger
+   gesture needed, and it doesn't collide with the note-editing touch handlers.
+   It only reads/writes container.scrollLeft, so it stays in sync with the
+   two-finger drag and the playhead-follow auto-scroll. */
+.grid-scrollbar {
+  position: relative;
+  height: 18px;
+  margin: 6px 0 2px;
+  border-radius: 999px;
+  background: var(--grid-line);
+  touch-action: none;
+  cursor: pointer;
+}
+
+.grid-scrollbar-thumb {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  min-width: 48px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.32);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
+  cursor: grab;
+  touch-action: none;
+  transition: background 0.12s ease;
+}
+
+.grid-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.grid-scrollbar-thumb:active {
+  cursor: grabbing;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+/* Whole song already fits — thumb fills the track and isn't draggable. */
+.grid-scrollbar-thumb--full {
+  cursor: default;
+  opacity: 0.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  .grid-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.38);
+  }
+  .grid-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.5);
+  }
+  .grid-scrollbar-thumb:active {
+    background: rgba(255, 255, 255, 0.62);
+  }
 }
 
 .labels {


### PR DESCRIPTION
## 概要

タブレットで譜面を横スクロールしづらい問題（先生要望、#85）への対応。**自前の太い常時表示スクロールバー**をグリッド下に追加しました。

## 背景・原因

- グリッドの各セルが `touch-action: none` でブラウザ標準の指スクロールを無効化 → 一本指では原理的にスクロール不可（必ず二本指が必要）
- 二本指スクロールも自前実装で慣性なし・両指をグリッド上に置く必要・音符入力と競合
- 標準バーは細く自動非表示、しかも **iPad Safari では CSS で太くできない**（`::-webkit-scrollbar` 無効）

## 実装

`GridScrollbar` コンポーネントを新規追加し、グリッド下に常時表示。標準バーは非表示化。

- **一本指でツマミをドラッグ／トラックをタップ**して移動。大きな当たり判定、音符入力ハンドラと非干渉
- `container.scrollLeft` を読み書きするだけ → 二本指スクロール・再生追従と自動同期。操作時は `measure()` を同期呼び出しして指に吸い付く
- ツマミ幅は表示範囲に比例（最小48px）。曲が収まる場合はトラック全幅＋淡色で非ドラッグ
- `role="scrollbar"` ＋ `aria-controls`/`aria-valuenow`。丸ピル、light/dark 対応
- 二本指スクロールは維持（後退なし・追加のみ）

## 検証

- `tsc --noEmit` クリーン / `pnpm lint` クリーン / vitest 57 passed
- プレビュー（tablet 768幅、grid 2616px > viewport 720px で横溢れ）実測:
  - バー描画: 高さ18px、`role=scrollbar`、`aria-controls=grid-scroll-area`、標準バー非表示（`scrollbar-width: none`）
  - ツマミドラッグ +200px → `scrollLeft` 727 / `translateX(200px)` / `aria-valuenow` 38、戻し -120px → 291 / 80px / 15（比例一致）
  - トラック90%タップ → `scrollLeft` 最大1896 / 右端 / 100
  - 音符入力の回帰なし（空セルクリックで音符追加を確認）
- スクリーンショットで丸ピルの見た目・配置を確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)