### PR TITLE
fix(editor): 「つくる」でまっさらな譜面を開く（前の譜面を復元しない）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,6 +83,17 @@ export default function Home() {
     preloadPianoSamples();
   }, []);
 
+  // ?new=1 —「つくる」from /songs: start from a plain sheet. reset() clears
+  // the song, the undo history, and the stored work, so the previous sheet
+  // isn't restored (that restore is #78's protection against *accidental*
+  // navigation — browser back / reload — which carries no ?new).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("new")) return;
+    reset();
+    window.history.replaceState({}, "", "/");
+  }, [reset]);
+
   // ?load=<id> で曲を読み込む
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/src/app/songs/page.tsx
+++ b/src/app/songs/page.tsx
@@ -82,7 +82,11 @@ export default function SongsPage() {
   return (
     <div className="songs-page">
       <header className="songs-header">
-        <Link href="/" className="songs-back-btn">
+        {/* つくる means "make a new song": ?new=1 tells the editor to start
+            from a plain sheet instead of restoring the previous work.
+            Browser back / reload carry no ?new, so accidental navigation
+            still restores the in-progress song (#78). */}
+        <Link href="/?new=1" className="songs-back-btn">
           {t.backToCreate}
         </Link>
         <h1 className="songs-heading">{t.pageTitle}</h1>


### PR DESCRIPTION
## 概要

曲を開く → みんなの曲 → 「← つくる」で、①の譜面が再度開かれるバグの修正（#87）。「つくる」は新規作成の意図なので、まっさらな譜面を開くようにしました。

## 原因

- 「← つくる」は単なる `/` へのリンク
- エディタはマウント時に sessionStorage の作業中譜面を復元する（#78 の誤操作保護）ため、直前の譜面が戻ってきていた

## 実装

- 「← つくる」リンクを `/?new=1` に変更（[songs/page.tsx](src/app/songs/page.tsx)）
- エディタ側で `?new` を検出したら既存の `reset()`（デフォルト曲・undo履歴・sessionStorage をクリア）を実行し、`replaceState` で URL を掃除（[page.tsx](src/app/page.tsx)）
- ブラウザバック・リロードには `?new` が付かないので、**#78 の誤操作保護はそのまま維持**

## トレードオフ（仕様）

作曲途中に「つくる」を押すと未保存の譜面は消えます（ボタンの意味どおり）。保存済みの曲は「みんなの曲」から開き直せます。誤操作（バック・リロード）では引き続き消えません。

## 検証（ブラウザ実測）

- 音符2つ配置 → /songs → 「つくる」→ **譜面0個・URL `/` に掃除・storage クリア** ✓
- 音符2つ配置 → /songs → **ブラウザバック → 2音符復元** ✓
- **リロード → 2音符復元** ✓
- `tsc --noEmit` クリーン / `pnpm lint` クリーン / vitest 57 passed

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)