### PR TITLE
fix(db): クラス名を半角数字に正規化（4 / ４ / ４組 の表記ゆれ解消）

### DIFF
--- a/supabase/migrations/0009_normalize_class_name.sql
+++ b/supabase/migrations/0009_normalize_class_name.sql
@@ -1,0 +1,74 @@
+-- 0009: normalize class names to half-width digits (#89)
+--
+-- Kids typed the same class as 2 / ２ / 2組 / 4年2組 / 5‐1, so one class
+-- splits into several filter options on /songs. Normalize at the database so
+-- every write path is covered (the client sends class_name as typed and shows
+-- whatever the upsert returns).
+--
+-- Rule:
+--   1. full-width digits → half-width; trim (incl. full-width space); '' → null
+--   2. if the string contains digits, keep the LAST digit run, leading zeros
+--      stripped: ２→2, 2組→2, 4年2組→2 (grade lives in its own column),
+--      5‐1→1
+--   3. no digits at all (e.g. 'A') → keep as typed, just trimmed
+
+create or replace function public.normalize_class_name(raw text)
+returns text
+language plpgsql
+immutable
+set search_path to ''
+as $$
+declare
+  s text;
+  digits text;
+begin
+  if raw is null then
+    return null;
+  end if;
+  s := btrim(translate(raw, '０１２３４５６７８９', '0123456789'), ' 　' || E'\t');
+  if s = '' then
+    return null;
+  end if;
+  digits := (regexp_match(s, '([0-9]+)[^0-9]*$'))[1];
+  if digits is not null then
+    return coalesce(nullif(ltrim(digits, '0'), ''), '0');
+  end if;
+  return s;
+end;
+$$;
+
+-- Normalize on every profile write. The songs snapshot trigger copies
+-- class_name from profiles on insert, so clean profiles keep songs clean.
+create or replace function public.profiles_normalize_class()
+returns trigger
+language plpgsql
+set search_path to ''
+as $$
+begin
+  new.class_name := public.normalize_class_name(new.class_name);
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_normalize_class on public.profiles;
+create trigger profiles_normalize_class
+  before insert or update on public.profiles
+  for each row execute function public.profiles_normalize_class();
+
+-- Fix existing data.
+update public.profiles
+set class_name = public.normalize_class_name(class_name)
+where class_name is distinct from public.normalize_class_name(class_name);
+
+-- songs.class_name is a frozen snapshot: songs_class_snapshot_upd reverts any
+-- update, and songs_touch_updated_at must not treat this correction as an
+-- edit. Disable both just for this one statement.
+alter table public.songs disable trigger songs_class_snapshot_upd;
+alter table public.songs disable trigger songs_touch_updated_at;
+
+update public.songs
+set class_name = public.normalize_class_name(class_name)
+where class_name is distinct from public.normalize_class_name(class_name);
+
+alter table public.songs enable trigger songs_class_snapshot_upd;
+alter table public.songs enable trigger songs_touch_updated_at;


### PR DESCRIPTION
## 概要

クラス設定が {4, ４, ４組} など同じクラスでも別クラスとして登録できてしまう問題の修正（#89）。DB を単一の正として正規化します。**適用済み**（migration `normalize_class_name`）。

## 実データのばらつき（修正前）

- profiles: `2`(5) / `２`(16) / `2組`(1) / `３`(1) / `4`(1) / `4年2組`(1) / `5‐1`(1)
- songs: `2`(20) / `２`(30) / `2組`(1) / `３`(1) / `4`(2) / `4年2組`(5)

## 正規化ルール（`normalize_class_name()`）

1. 全角数字→半角、前後空白（全角スペース含む）除去、空→NULL
2. 数字を含む場合: **最後の数字の連なり**を採用、先頭ゼロ除去 — `２`→`2`、`2組`→`2`、`4年2組`→`2`（該当者の grade=4 を実データで確認済み。学年は別カラム）、`5‐1`→`1`（grade=5 確認済み）
3. 数字なし（`A` など）: トリムのみでそのまま

## 実装（migration 0009）

- `profiles` への **BEFORE INSERT/UPDATE トリガー** — 今後の全書き込みパスを正規化。クライアント変更は不要（`saveProfile` は upsert 後に select した値で state を更新するため UI へ自動反映。songs への snapshot も profiles 経由で常にきれい）
- **既存データ是正**: profiles / songs の class_name を UPDATE。songs は `songs_class_snapshot_upd`（凍結トリガー、更新を旧値に戻す）と `songs_touch_updated_at`（是正を編集扱いにしない）をその文の間だけ無効化

## 検証

**ロールバックTx で事前検証** → 本適用 → 事後検証の順:
- 単体13ケース全合格（`２`→2、`2組`→2、`4年2組`→2、`5‐1`→1、`　`→NULL、`04`→4、`A`→A など）
- 是正結果: profiles 7表記 → `1`(1)/`2`(23)/`3`(1)/`4`(1)、songs → `2`(56)/`3`(1)/`4`(2)
- **updated_at の変化 0件**
- トリガー動作: `３組` で UPDATE → `3` で保存
- 全トリガー有効に復帰（無効化した2つ含む）
- ブラウザ: /songs のクラスフィルタが `2 / 3 / 4` に統合されたことを確認

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)