### PR TITLE
test(core): BLOCKS_MAX の clamp テストを定数参照化＋値ガード追加

### DIFF
--- a/src/core/legacy.test.ts
+++ b/src/core/legacy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { migrateSong } from "./legacy";
-import { DEFAULT_SONG } from "./defaults";
+import { BLOCKS_MAX, DEFAULT_SONG } from "./defaults";
 
 describe("migrateSong", () => {
   it("passes a current (v2/blocks) song through unchanged", () => {
@@ -66,7 +66,7 @@ describe("migrateSong", () => {
 
   it("clamps an over-long migrated length to the max", () => {
     const out = migrateSong({ version: 1, bars: 100, stepsPerBeat: 4 });
-    expect(out.blocks).toBe(32); // BLOCKS_MAX
+    expect(out.blocks).toBe(BLOCKS_MAX);
   });
 
   it("falls back to the default length when none is present", () => {

--- a/src/core/ops.test.ts
+++ b/src/core/ops.test.ts
@@ -13,7 +13,7 @@ import {
   setAllowedNotes,
   clearAllowedNotes,
 } from "./ops";
-import { DEFAULT_SONG } from "./defaults";
+import { BLOCKS_MAX, DEFAULT_SONG } from "./defaults";
 import type { Song } from "./types";
 
 const base = (): Song => structuredClone(DEFAULT_SONG); // C4..C5, blocks 16 (total 64)
@@ -138,9 +138,19 @@ describe("adjustPitchBound", () => {
   });
 });
 
+describe("BLOCKS_MAX", () => {
+  // Guards the *value* of the ceiling (96 blocks = 384 cells wide), separate
+  // from the clamp-behaviour tests below which reference the constant. Raising
+  // the max blows up the grid's DOM width, so it has to be done consciously
+  // here rather than slipping in unnoticed.
+  it("caps the grid at a sane width", () => {
+    expect(BLOCKS_MAX).toBeLessThanOrEqual(96);
+  });
+});
+
 describe("setBlocks", () => {
   it("clamps to the allowed range", () => {
-    expect(setBlocks(base(), 999).blocks).toBe(32);
+    expect(setBlocks(base(), 999).blocks).toBe(BLOCKS_MAX);
     expect(setBlocks(base(), 0).blocks).toBe(1);
   });
 


### PR DESCRIPTION
## 概要

`BLOCKS_MAX` を 32→96 に変更（`0348152`）した際、`32` を直書きしていた2つのテストが失敗していた（main が壊れた状態で push 済み）ため修正。あわせて、テストが混在させていた2つの関心事を分離しました。

## 変更

1. **クランプ挙動テスト**（`setBlocks` / `migrateSong` の over-long）→ `toBe(BLOCKS_MAX)` に変更
   - クランプを外す・壊すと範囲外入力が素通りして落ちるので検証力は維持。上限を意図的に変えても巻き込まれない
2. **値ガードを新設**（`BLOCKS_MAX` ≤ 96）
   - 上限を上げると grid の DOM 幅が膨らむため、意識的にここを直さないと通らない canary。定数参照が手放す「値の見張り」を明示的に復活

## 検証

- `tsc --noEmit` クリーン / `pnpm lint` クリーン / **vitest 58 passed**（新規ガード含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)