### PR TITLE
feat(profile): クラスを選択式（1〜10, A〜G）にする

### DIFF
--- a/src/app/components/ProfileModal.tsx
+++ b/src/app/components/ProfileModal.tsx
@@ -6,9 +6,14 @@ import type { Gender, Profile, ProfileEdits } from "@/hooks/useProfile";
 
 const GENDERS: Gender[] = ["male", "female", "other", "undisclosed"];
 const GRADES = [1, 2, 3, 4, 5, 6];
+// Class is a fixed picker (numbers then letters) so the same class can't be
+// typed in variants (半角/全角/「組」つき) that split it into separate tabs.
+const CLASS_OPTIONS = [
+  ...Array.from({ length: 10 }, (_, i) => String(i + 1)), // 1..10
+  ..."ABCDEFG".split(""), // A..G
+];
 const MAX_NAME = 60;
 const MAX_SCHOOL = 100;
-const MAX_CLASS = 40;
 
 interface Props {
   t: Translations;
@@ -44,6 +49,13 @@ export function ProfileModal({ t, profile, onSave, onClose }: Props) {
   const [gender, setGender] = useState<Gender | null>(profile?.gender ?? null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Keep an already-stored class visible even if it predates this fixed list
+  // (e.g. a legacy value the normalization left as-is), so saving can't drop it.
+  const classOptions =
+    className && !CLASS_OPTIONS.includes(className)
+      ? [className, ...CLASS_OPTIONS]
+      : CLASS_OPTIONS;
 
   const handleSave = async () => {
     setSaving(true);
@@ -113,13 +125,18 @@ export function ProfileModal({ t, profile, onSave, onClose }: Props) {
 
           <label className="modal-field">
             <span className="modal-label">{t.profileClass}</span>
-            <input
+            <select
               className="modal-input"
-              placeholder={t.profileClassPlaceholder}
               value={className}
               onChange={(e) => setClassName(e.target.value)}
-              maxLength={MAX_CLASS}
-            />
+            >
+              <option value="">{t.profileNotSet}</option>
+              {classOptions.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
           </label>
 
           <label className="modal-field">

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -107,7 +107,6 @@ export type Translations = {
   profileSaved: string;
   profileSaveFailed: string;
   profileSchoolPlaceholder: string;
-  profileClassPlaceholder: string;
   profileNamePlaceholder: string;
 };
 
@@ -211,7 +210,6 @@ export const translations: Record<Locale, Translations> = {
     profileSaved: "Saved!",
     profileSaveFailed: "Couldn't save. Please try again.",
     profileSchoolPlaceholder: "School name",
-    profileClassPlaceholder: "e.g. 1, A",
     profileNamePlaceholder: "Your name or nickname",
   },
   ja: {
@@ -313,7 +311,6 @@ export const translations: Record<Locale, Translations> = {
     profileSaved: "ほぞんしました！",
     profileSaveFailed: "ほぞんに しっぱいしました。もういちど ためしてね。",
     profileSchoolPlaceholder: "がっこうのなまえ",
-    profileClassPlaceholder: "れい: 1、A",
     profileNamePlaceholder: "なまえ か ニックネーム",
   },
 };


### PR DESCRIPTION
## 概要

クラスを自由入力から選択式にしました（先生要望、#92）。学年はすでに選択式なので、クラスも揃えて入り口で表記ゆれを防ぎます。

## 背景

クラスが自由入力だったため、同じクラスでも半角/全角/「組」つきで別クラス扱いになり /songs のタブが分裂していました（#89 で DB は正規化済み。本 PR は入り口を塞ぐ対応）。

## 実装（クライアントのみ）

- `ProfileModal` のクラス欄を `<input>` → `<select>` に変更
  - 選択肢: 未設定(—) / `1`〜`10` / `A`〜`G`（数字→英字）
  - 既存の保存値が一覧に無い場合は先頭に補完して表示 → 選択式化で既存値を保存時に取りこぼさない（防御的）
- 不要になった `MAX_CLASS` と i18n の `profileClassPlaceholder` を削除

DB 正規化トリガー（#89）は安全網として維持、migration 不要。既存データ（`1`〜`4`）は全て新しい選択肢に含まれます。

## 検証

- `tsc --noEmit` クリーン / `pnpm lint` クリーン / vitest 58 passed
- 選択肢ロジックをブラウザで実測: `1〜10, A〜G`（17）＋未設定=18項目、既存 `1〜4` を全カバー、レガシー値の防御的保持も確認
- モーダルは Google ログイン必須のため、認証情報を入力しない方針からクリックスルーは実施せず、ロジック＋型チェック＋同ファイルの grade/gender select との同形で担保

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)