### PR TITLE
feat(save): 攻撃的・性的な曲名/作者名に2段階対応（リフレクト・ナッジ＋ブロック）

### DIFF
--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { Song } from "@/core/types";
 import type { Locale, Translations } from "@/lib/i18n";
 import { translations } from "@/lib/i18n";
@@ -10,6 +10,7 @@ import {
   MAX_AUTHOR_LENGTH,
   validateSongMeta,
   songWithinSizeLimit,
+  containsSensitiveWord,
 } from "@/lib/validation";
 
 // Map a Supabase save error to a message a child can act on. The raw error is
@@ -64,6 +65,13 @@ export function SaveModal({
   // After a successful new save, show a confirmation telling the child what
   // happened and where the song went, instead of silently closing.
   const [savedAs, setSavedAs] = useState<"draft" | "public" | null>(null);
+  // Reflection nudge: when the title/author holds a sensitive (not blocked)
+  // word, pause once and ask the child to reconsider before the save runs.
+  const [reflecting, setReflecting] = useState(false);
+  // The save to run if they proceed past the nudge, and a latch so we only
+  // nudge once per name (reset when they edit the title/author).
+  const pendingSaveRef = useRef<(() => void) | null>(null);
+  const reflectionAckedRef = useRef(false);
 
   const guard = (): boolean => {
     const meta = validateSongMeta({ title, author });
@@ -80,8 +88,8 @@ export function SaveModal({
     return true;
   };
 
-  const run = async (op: () => Promise<{ error: unknown }>, onSuccess: () => void) => {
-    if (!guard()) return;
+  // The DB call itself, with no pre-checks — used once the nudge is cleared.
+  const execute = async (op: () => Promise<{ error: unknown }>, onSuccess: () => void) => {
     setSaving(true);
     setError(null);
     try {
@@ -98,6 +106,37 @@ export function SaveModal({
     } finally {
       setSaving(false);
     }
+  };
+
+  const run = (op: () => Promise<{ error: unknown }>, onSuccess: () => void) => {
+    if (!guard()) return;
+    // Sensitive (not blocked) word → reflection nudge. Blocked words never get
+    // here: guard() rejects them first. Stash the save and let the child decide.
+    if (
+      !reflectionAckedRef.current &&
+      (containsSensitiveWord(title) || containsSensitiveWord(author))
+    ) {
+      pendingSaveRef.current = () => execute(op, onSuccess);
+      setReflecting(true);
+      return;
+    }
+    execute(op, onSuccess);
+  };
+
+  // "このままで ほぞん" — proceed with the stashed save; don't nudge again for
+  // this name.
+  const proceedPastReflection = () => {
+    reflectionAckedRef.current = true;
+    setReflecting(false);
+    const pending = pendingSaveRef.current;
+    pendingSaveRef.current = null;
+    pending?.();
+  };
+
+  // "なまえを かえる" — back to the form without saving.
+  const cancelReflection = () => {
+    pendingSaveRef.current = null;
+    setReflecting(false);
   };
 
   // New saves pick their visibility explicitly (the child chooses; nothing is
@@ -131,6 +170,29 @@ export function SaveModal({
 
   const canSave = !saving && !!title.trim() && !!author.trim();
 
+  // Reflection nudge: a kind, one-question pause before a sensitive name is
+  // saved. "Change the name" is the primary (green) action; "save anyway" is
+  // the quiet secondary. We never show which word tripped it — the point is to
+  // prompt a moment of thought, not to teach the word or play banned-word bingo.
+  if (reflecting) {
+    return (
+      <div className="modal-overlay" onClick={onClose}>
+        <div className="modal" onClick={(e) => e.stopPropagation()}>
+          <h2 className="modal-title">{t.reflectTitle}</h2>
+          <p className="modal-warn">{t.reflectBody}</p>
+          <div className="modal-actions">
+            <button className="modal-cancel" onClick={proceedPastReflection}>
+              {t.reflectSaveAnyway}
+            </button>
+            <button className="modal-save" onClick={cancelReflection} autoFocus>
+              {t.reflectChangeName}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // Post-save confirmation: say what happened and where the song went.
   if (savedAs) {
     return (
@@ -161,6 +223,7 @@ export function SaveModal({
             onChange={(e) => {
               setTitle(e.target.value);
               if (error) setError(null);
+              reflectionAckedRef.current = false; // a new name gets a fresh nudge
             }}
             maxLength={MAX_TITLE_LENGTH}
             autoFocus
@@ -172,6 +235,7 @@ export function SaveModal({
             onChange={(e) => {
               setAuthor(e.target.value);
               if (error) setError(null);
+              reflectionAckedRef.current = false; // a new name gets a fresh nudge
             }}
             maxLength={MAX_AUTHOR_LENGTH}
           />

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -34,6 +34,10 @@ export type Translations = {
   cancel: string;
   saving: string;
   saveErrorBlockedWord: string;
+  reflectTitle: string;
+  reflectBody: string;
+  reflectChangeName: string;
+  reflectSaveAnyway: string;
   saveErrorTooLarge: string;
   saveErrorFailed: string;
   saveErrorAuth: string;
@@ -139,7 +143,12 @@ export const translations: Record<Locale, Translations> = {
     authorPlaceholder: "Your name",
     cancel: "Cancel",
     saving: "Saving...",
-    saveErrorBlockedWord: "That title or name can't be used.",
+    saveErrorBlockedWord: "This name can't be used. Please pick another one.",
+    reflectTitle: "Wait a sec",
+    reflectBody:
+      "Could this name make a friend feel sad or upset? Take another look before you save.",
+    reflectChangeName: "Change the name",
+    reflectSaveAnyway: "Save anyway",
     saveErrorTooLarge: "This song is too large to save.",
     saveErrorFailed: "Couldn't save. Please try again.",
     saveErrorAuth: "Your login may have expired. Please log out and log in again.",
@@ -240,7 +249,12 @@ export const translations: Record<Locale, Translations> = {
     authorPlaceholder: "あなたのなまえ",
     cancel: "キャンセル",
     saving: "ほぞんちゅう...",
-    saveErrorBlockedWord: "つかえない ことばが はいっています。",
+    saveErrorBlockedWord: "この なまえは つかえないよ。ちがう なまえに してね。",
+    reflectTitle: "ちょっと まってね",
+    reflectBody:
+      "その なまえを 見た ともだちが、いやな きもちに なったり、かなしく ならないかな？ もういちど かんがえてみよう。",
+    reflectChangeName: "なまえを かえる",
+    reflectSaveAnyway: "このままで ほぞん",
     saveErrorTooLarge: "きょくが おおきすぎて ほぞんできません。",
     saveErrorFailed: "ほぞんに しっぱいしました。もういちど ためしてね。",
     saveErrorAuth: "ログインの ゆうこうきげんが きれたかも。一度 ログアウトして、もう一度 ログインしてね。",

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   validateSongMeta,
   containsBlockedWord,
+  containsSensitiveWord,
+  normalizeForMatch,
   songWithinSizeLimit,
   MAX_TITLE_LENGTH,
   MAX_AUTHOR_LENGTH,
@@ -51,6 +53,51 @@ describe("containsBlockedWord", () => {
     expect(containsBlockedWord("ShItpost")).toBe(true);
     expect(containsBlockedWord("happy song")).toBe(false);
   });
+
+  it("sees through width / kana / spacing / symbol dodges", () => {
+    for (const dodge of ["死ね", "し ね", "シネ", "ｼﾈ", "し☆ね", "ＦＵＣＫ"]) {
+      expect(containsBlockedWord(dodge)).toBe(true);
+    }
+  });
+
+  it("does not flag mischief words (those are sensitive, not blocked)", () => {
+    expect(containsBlockedWord("うんこ")).toBe(false);
+    expect(containsBlockedWord("ちんこ")).toBe(false);
+  });
+});
+
+describe("normalizeForMatch", () => {
+  it("folds width, case, kana, and wedged separators", () => {
+    expect(normalizeForMatch("ＦＵＣＫ")).toBe("fuck");
+    expect(normalizeForMatch("シネ")).toBe("しね");
+    expect(normalizeForMatch("ｼﾈ")).toBe("しね");
+    expect(normalizeForMatch("し ね")).toBe("しね");
+    expect(normalizeForMatch("し☆ね")).toBe("しね");
+  });
+});
+
+describe("containsSensitiveWord", () => {
+  it("flags mischief words, including inside a longer title", () => {
+    expect(containsSensitiveWord("うんこ")).toBe(true);
+    expect(containsSensitiveWord("うんこブギ")).toBe(true);
+    expect(containsSensitiveWord("バカ")).toBe(true); // katakana
+  });
+
+  it("does not flag the hard-block words (block takes over for those)", () => {
+    expect(containsSensitiveWord("死ね")).toBe(false);
+  });
+});
+
+describe("innocent titles stay clean (false-positive guard)", () => {
+  // Each collides with a word we deliberately left OUT of the lists, so it
+  // must NOT trip either tier: 激しい↛はげ, かすみ↛カス, 結末↛けつ.
+  const innocent = ["きらきらぼし", "激しいビート", "かすみそう", "けつまつ", "My Song"];
+  for (const title of innocent) {
+    it(`allows "${title}"`, () => {
+      expect(containsBlockedWord(title)).toBe(false);
+      expect(containsSensitiveWord(title)).toBe(false);
+    });
+  }
 });
 
 describe("songWithinSizeLimit", () => {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -9,18 +9,91 @@ export const MAX_AUTHOR_LENGTH = 40;
 // Generous ceiling on the serialized song to stop abusive payloads.
 export const MAX_SONG_BYTES = 100_000;
 
-// Starter blocklist — intentionally small. Expand or, better, replace with a
-// server-side moderation service. Matching is case-insensitive substring.
+// Two tiers of word matching, both applied to the title and author:
+//
+//   BLOCKED   — never publishable on a classroom feed (explicit sexual terms,
+//               slurs, "die/kill"). Hard-stops the save.
+//   SENSITIVE — the mischief kids reach for (toilet words, mild jabs). NOT
+//               blocked: the save modal shows a one-time reflection nudge
+//               ("could this hurt someone?") and lets them proceed. The point
+//               is the pause, not censorship — and because it only warns, the
+//               occasional false positive costs nothing.
+//
+// Lists are deliberately short and starter-grade; expand in review, or move to
+// a server-side service. Kept low-false-positive on purpose: e.g. はげ / けつ /
+// カス are omitted because they collide with 激しい / 結末 / かすみ (a name).
 const BLOCKED_WORDS = [
   "fuck",
   "shit",
   "bitch",
   "asshole",
   "slut",
+  "cunt",
+  "死ね",
   "しね",
   "ころす",
-  "きもい",
+  "殺す",
+  "きえろ",
+  "消えろ",
+  "まんこ",
+  "セックス",
+  "きちがい",
 ];
+
+const SENSITIVE_WORDS = [
+  "うんこ",
+  "うんち",
+  "おしっこ",
+  "ゲロ",
+  "おなら",
+  "ちんこ",
+  "ちんちん",
+  "おちんちん",
+  "ばか",
+  "あほ",
+  "きもい",
+  "きしょい",
+  "うざい",
+  "ぶす",
+  "でぶ",
+  "くそ",
+  "だまれ",
+  "あっちいけ",
+];
+
+// Fold away the ways a kid dodges a word list: full/half width, upper case,
+// katakana vs hiragana, and any spaces or symbols wedged between characters
+// (し ね, し☆ね). Matching then runs on this normalized form.
+export function normalizeForMatch(text: string): string {
+  return (
+    text
+      .normalize("NFKC")
+      .toLowerCase()
+      // katakana → hiragana (so シネ / ｼﾈ match しね)
+      .replace(/[ァ-ヶ]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0x60))
+      // drop everything that isn't a letter or number: spaces, punctuation,
+      // symbols wedged between characters
+      .replace(/[^\p{L}\p{N}]/gu, "")
+  );
+}
+
+const BLOCKED_NORMALIZED = BLOCKED_WORDS.map(normalizeForMatch);
+const SENSITIVE_NORMALIZED = SENSITIVE_WORDS.map(normalizeForMatch);
+
+function matchesAny(text: string, normalizedList: string[]): boolean {
+  const normalized = normalizeForMatch(text);
+  return normalizedList.some((word) => word.length > 0 && normalized.includes(word));
+}
+
+export function containsBlockedWord(text: string): boolean {
+  return matchesAny(text, BLOCKED_NORMALIZED);
+}
+
+// A sensitive (but not blocked) word — the save flow turns this into a
+// reflection nudge rather than a hard stop.
+export function containsSensitiveWord(text: string): boolean {
+  return matchesAny(text, SENSITIVE_NORMALIZED);
+}
 
 export type MetaValidationReason =
   | "title-empty"
@@ -30,11 +103,6 @@ export type MetaValidationReason =
   | "blocked-word";
 
 export type MetaValidation = { ok: true } | { ok: false; reason: MetaValidationReason };
-
-export function containsBlockedWord(text: string): boolean {
-  const normalized = text.trim().toLowerCase();
-  return BLOCKED_WORDS.some((word) => normalized.includes(word));
-}
 
 export function validateSongMeta(input: { title: string; author: string }): MetaValidation {
   const title = input.title.trim();


### PR DESCRIPTION
## 概要

児童が曲名・作者名に「死ね」「うんこ」「ちんこ」等を使う件への対応（システムupdate、#94）。検閲一辺倒でなく、**大半は"考えてみよう"の確認（ナッジ）で学びにし**、露骨な語だけ公開不可にする2段階です（Instagram/Twitter 等で暴言減少が報告されている手法）。

## 実装（v1・クライアント）

### [validation.ts](src/lib/validation.ts)
- `normalizeForMatch()`: NFKC（全/半角）＋小文字化＋カタカナ→ひらがな＋空白/記号除去 → `し ね`『シネ』『し☆ね』を同一視
- 2リスト: **BLOCKED**（露骨な性的語・差別語・死ね/殺す＝ハードストップ）／**SENSITIVE**（トイレ・軽い悪口＝ナッジ、新規）
- 誤検知を避けてリスト調整: `はげ/けつ/カス` は `激しい/結末/かすみ(名前)` と衝突するため不採用。曖昧な語はブロックでなくナッジ側へ（ナッジは誤検知が"やさしい確認"で済む）

### [SaveModal.tsx](src/app/components/SaveModal.tsx)
- センシティブ語 → **リフレクト画面を一度だけ**表示:
  > ちょっと まってね／その なまえを 見た ともだちが、いやな きもちに なったり、かなしく ならないかな？ もういちど かんがえてみよう。
  - **「なまえを かえる」（緑・主）** ／ 「このままで ほぞん」（控えめ・副）
- 検知語は画面に出さない（語の強化・当てゲーム化を防ぐ）／名前を編集するとナッジ再判定
- ブロック語は従来どおり弾く（メッセージをやさしい文言に）
- 対象は **タイトル＋作者名** 両方

## 検証（ブラウザ・songs POST をインターセプトして本番DB非書き込み）

- `うんこ`/`ちんこ` → ナッジ表示（保存前で停止・DB書き込み0）
- ナッジ「このままで ほぞん」→ 保存に進む（モック確認）／「なまえを かえる」→ フォームに戻る
- `死ね`・`し ね`（空白回避）→ ブロックエラー・保存不可
- スクリーンショットで見た目確認
- `tsc`/`lint` クリーン、**vitest 68 passed**（新規10: 正規化・回避・tier分離・誤検知ガード）

## 既知の限界（正直な注記）
- `しね`（ひらがな）は「たのしいし、ね」等でごくまれに誤ブロックし得る。目立てば `しね`→ナッジ、`死ね`(漢字)のみブロックへ調整可
- 完全なリストは存在せず運用で追加する前提。クライアントのみ＝UXガード（anon key 直叩き可）

## 続き（別PR予定）
- **v1.5**: BLOCKED をサーバ trigger で強制 → client 迂回でも公開されず、#31 に着手

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)