### PR TITLE
perf: ピアノ音源を immutable 配信して Edge Requests を削減（月90万→約25万見込み）

### DIFF
--- a/public/samples/piano/README.md
+++ b/public/samples/piano/README.md
@@ -12,3 +12,19 @@ hosted because Safari cannot decode ogg.
 Loaded by `src/audio/engine.ts` via smplr's `SplendidGrandPiano` with
 `baseUrl: "/samples/piano"`. Self-hosted (rather than the smpldsnds CDN)
 so school networks that whitelist only the app's domain can load them.
+
+## Replacing these files
+
+`vercel.json` serves `/samples/*` as `immutable` for a year, so browsers
+never re-check them — that's what keeps a page load from re-requesting 44
+files (see #100). The trade-off: overwriting a file in place would leave
+already-cached devices on the old audio forever.
+
+So to change a sample, **put the new set under a fresh path** (e.g.
+`/samples/piano/v2/`), point `PIANO_BASE_URL` at it, and **delete the old
+directory in the same PR** — `public/` ships as-is, so one version in the
+repo means one version deployed, no stale leftovers.
+
+A tab left open across that deploy requests the old path, gets a 404, and
+falls back to the 8bit voice until it reloads (the custom `Storage` in
+`engine.ts` rejects on non-200 precisely so that fallback engages).

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/samples/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 問題

Vercel の Edge Requests が直近30日で **901K / 1M**（無料枠突破間近）。

## 原因（本番で実測）

エディタ `/` を1回開くと **約58リクエスト**、うち **44件がピアノ音源**（76%）。→ 901K のうち**推定約68万件が音源**。

決定的なのは**キャッシュヘッダ**でした:

```
/samples/piano/*.ogg      → public, max-age=0, must-revalidate   ← public/ の Vercel 既定
/_next/static/chunks/*.js → public, max-age=31536000, immutable  ← Next.js が付与
```

`max-age=0` は「使う前に必ずサーバへ確認」なので、**304 が返るだけでも 1 Edge Request**。
Vercel は **CDN HIT でもカウント**するため CDN キャッシュでは減らず、**ブラウザに聞きに来させない**しかない。

アプリの Cache API 保存は同一端末の利用中は効くが、iPad Safari は JS 保存ストレージを数日で追い出す（ITP・容量圧迫。音源9.4MB）。その際 `max-age=0` のため **HTTP キャッシュが受け皿にならず44件が丸ごと再取得**される。

## 対応

`vercel.json` を追加し `/samples/*` を `max-age=31536000, immutable` で配信。
`immutable` は**リロードでも再確認しない**点が重要（児童は頻繁にリロードする）。

あわせて音源 README に**差し替え手順**を明記: パスにバージョンを付け（`/samples/piano/v2/`）**同じPRで旧ディレクトリを削除**。`public/` は Git の中身がそのままデプロイ成果物なので、外部ストレージにゴミは残らない。デプロイをまたいだ古いタブは旧パスで404→**既存実装が8bitへフォールバック**（`engine.ts` の独自 Storage がこのケースを想定済み）、リロードで復帰。

## 効果（見込み）

| | 現状 | 本PR後 |
|---|---|---|
| 端末の初回ロード | 44 | 44 |
| 2回目以降 | 44 | **0** |
| 月間 | 901K | **約25万** |

初回ロードの削減（44→8）は #101 で別途対応。

## 検証（プレビューデプロイで実測）

| パス | 変更前 | プレビュー |
|---|---|---|
| `/samples/piano/MF C4.ogg` | `max-age=0, must-revalidate` | **`max-age=31536000, immutable`** ✅ |
| `/`（HTML） | `no-store` | `no-store`（過剰キャッシュなし ✅） |
| `/_next/static/*.js` | `immutable` | `immutable`（変化なし ✅） |

ルールが `/samples/` にのみ適用され、HTML を誤ってキャッシュしていないことを確認。
`tsc`/`lint` クリーン、vitest 68 passed、`vercel.json` の JSON 妥当性も確認済み。

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)