### PR TITLE
perf: 曲カードのリンク先読みを止める（/songs 1表示 23件→0件）

### DIFF
--- a/src/app/components/SongCard.tsx
+++ b/src/app/components/SongCard.tsx
@@ -245,7 +245,12 @@ export function SongCard({
           </div>
         ) : (
           <div className="song-card-actions">
-            <Link href={`/?load=${id}`} className="song-card-play">
+            {/* prefetch={false}: Next.js would preload every card in view, and
+                /?load=<id> is a dynamic RSC route served no-store — so each one
+                is an uncacheable request (plus a function invocation) for a song
+                the child probably won't open. A feed page was spending ~23 of
+                them to save one navigation (#104). */}
+            <Link href={`/?load=${id}`} className="song-card-play" prefetch={false}>
               {t.playBtn}
             </Link>
             <button


### PR DESCRIPTION
## 概要

#100・#101 の後も Edge Requests が減らなかった原因への対応（#104）。本番で実測した結果、**エディタは直っていたが `/songs` が未対応で、そちらが主要因になっていた**ことが判明しました。

## 原因（本番実測）

`SongCard` の `<Link href={/?load=${id}}>` は Next.js のデフォルトで先読みされるため、**`/songs` を1回開くと約23件**のリクエストが発生。しかもそのレスポンスは:

```
cache-control: private, no-cache, no-store, max-age=0, must-revalidate
x-vercel-cache: MISS
```

**一切キャッシュされず**、動的RSCなので関数実行も伴います。24曲表示して児童が開くのは多くて1曲＝**約96%が捨てられている**。実機ではスクロールでカードが増えるほど先読みも増えます。

| ページ | #100/#101 前 | 現在 |
|---|---|---|
| エディタ（初回） | 約58 | 約21 |
| エディタ（2回目以降） | 約58 | **約1**（HTMLのみ、resource取得0件） |
| **`/songs`（毎回）** | 約37 | **約37（未対応）** |

児童は互いの曲を聴くため `/songs` を何度も開くので、エディタが58→1になっても総量が動きませんでした。
（加えて Vercel の表示は直近30日合計なので、修正前の日が大半を占め反映が遅れている点もあります。）

## 対応

Link に `prefetch={false}` を付与。`/songs` の先読みが **23件 → 0件**に。

- コスト: 「あそぞ」押下時の先読みが無くなり遷移がわずかに遅くなる
- 見返り: 24曲中1曲しか開かないため、捨てている96%が消える

`/?new=1` とエディタの `/songs` リンク（各1件・クリックされる可能性が高い）はそのまま残しました。

## 検証（ブラウザ実測）

- `/songs`: 曲カード24枚を表示して **プリフェッチ0件**（変更前23件）
  - ※6秒待って計測。**前回2.5秒で測って取り逃していたのが、#100/#101 の予測が過大だった原因**です
- 「あそぶ」クリック → **曲が正常に読み込まれる**（音符375個、URLは `/` に掃除、エラー通知なし）
- コンソールエラーなし、`tsc`/`lint` クリーン、vitest 68 passed

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)