### PR TITLE
perf: 一覧クエリから song_data を外す（1ページ 149KB→7KB・96%減）

### DIFF
--- a/src/hooks/useSongFeed.ts
+++ b/src/hooks/useSongFeed.ts
@@ -3,19 +3,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
-import type { Song } from "@/core/types";
 
 export type FeedView = "all" | "mine" | "templates";
 
 export type Visibility = "draft" | "unlisted" | "public";
 
+// Deliberately without song_data: the cards only show metadata, and the editor
+// re-fetches the song by id when one is opened. Carrying the note data through
+// the feed cost ~121KB per page of 24 (avg ~5KB/song) for bytes nobody read.
 export type FeedSong = {
   id: string;
   title: string;
   author: string;
   created_at: string;
   updated_at: string;
-  song_data: Song;
   user_id: string | null;
   is_template: boolean;
   visibility: Visibility;
@@ -25,7 +26,7 @@ export type FeedSong = {
 const PAGE_SIZE = 24;
 
 const SONG_COLUMNS =
-  "id, title, author, created_at, updated_at, song_data, user_id, is_template, visibility";
+  "id, title, author, created_at, updated_at, user_id, is_template, visibility";
 
 // Whether a song belongs to a view — mirrors the server-side filter, so a
 // locally-mutated song (template toggled, etc.) leaves/stays in the list


### PR DESCRIPTION
## 概要

`/songs` の一覧クエリが `song_data`（曲データ本体）を取得していましたが、**一覧UIはこれを一切使っていませんでした**（#106）。エディタは「あそぶ」で開いた時に id 指定で改めて取り直すので、一覧で運んでいた分は丸ごと捨てられていました。

## 効果（本番データ408曲で実測）

1ページ（24件）のレスポンスサイズ:

| | サイズ |
|---|---|
| 変更前（`song_data` あり） | **149 KB** |
| 変更後（`song_data` なし） | **7 KB** |
| **削減** | **142 KB（96%減）** |

このコストは**スクロールするたび**（24件ずつ）、さらに**検索・フィルタ・タブ切替のたび**に発生していました。

Vercel の Edge Requests には無関係（Supabase 直通信）ですが、**学校のWi-Fiでの体感速度**と Supabase の egress に直接効きます。

## 変更

- `SONG_COLUMNS` から `song_data` を除去
- `FeedSong` 型からも `song_data` を削除、未使用になった `Song` の import も削除
  - **読まれないフィールドを型に残していたことが、この無駄が見過ごされた原因**なので、型からも消しました

## 検証（ブラウザ実測）

- クエリURLに `song_data` が含まれないことを確認
- カード表示は正常（曲名・作者・「22時間まえ」）
- **もっと見る**: 24 → 48件（+1リクエスト）
- **検索**（300msデバウンス）: 7件
- **テンプレタブ**: 6件 → **みんなに戻る**: 24件
- **「あそぶ」で曲が正常に開く**: 音符375個、エラー通知なし（エディタ側の id 指定取得は変更なしだが回帰確認）
- コンソールエラーなし、`tsc`/`lint` クリーン、vitest 68 passed

## 注意

将来「カード上で試聴する」等、一覧で曲データが必要な機能を足す場合は戻す判断が必要です。その際も全件ではなく必要な時だけ取る形が望ましいです。

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)