### PR TITLE
作曲ページの操作ヘッダーをスクロール中も固定する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -378,8 +378,12 @@ export default function Home() {
   };
 
   const handleToggleSettings = () => {
-    setIsSettingsOpen((prev) => !prev);
+    const willOpen = !isSettingsOpen;
+    setIsSettingsOpen(willOpen);
     setIsConfirmingReset(false);
+    if (willOpen) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   };
 
   const handleNoteChipClick = useCallback(

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -110,7 +110,9 @@ a[href],
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow-x: hidden;
+  /* Unlike hidden, clip does not create a scroll container that prevents
+     the editor header's position: sticky from following the viewport. */
+  overflow-x: clip;
 }
 
 /* Dragging state */

--- a/src/app/styles/header.css
+++ b/src/app/styles/header.css
@@ -1,4 +1,7 @@
 .header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   background: var(--header-bg);
   padding: 12px 16px;
   display: flex;


### PR DESCRIPTION
## 変更内容

- 作曲ページの操作ヘッダーを `position: sticky` で画面上部に固定
- `.app` の横方向クリップを、stickyを阻害しない `overflow-x: clip` へ変更
- スクロール中に設定を開いた場合、設定パネルが固定ヘッダー直下に表示されるようページ先頭へ移動
- ヘッダーの重なり順を、通常コンテンツより上・発見演出やモーダルより下に整理

## 理由

グリッドを縦にスクロールしたあとも、再生・停止・Undo・設定・保存などの主要操作へすぐアクセスできるようにするためです。

単純にstickyを指定するだけでは、親要素の `overflow-x: hidden` がスクロールコンテナを作り、固定が機能しませんでした。`clip` に置き換えることで横方向のはみ出し防止を維持しつつ、ヘッダーをビューポートへ追従させています。

## 確認内容

- デスクトップ 1280px、タブレット 768px、モバイル 390pxでスクロール後もheader top = 0px
- 設定パネル、アカウントメニュー、保存モーダルの表示と重なり順
- 横方向のページオーバーフローなし
- TypeScript型チェック
- ESLint
- Vitest: 106 tests passed
- production build
- ブラウザコンソールエラーなし

Closes #113