### PR TITLE
設定パネル描画後にスクロール位置を補正する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -119,6 +119,17 @@ export default function Home() {
     return () => engineRef.current?.dispose();
   }, []);
 
+  // The settings panel is inserted above the editor content. Wait until React
+  // has committed it before scrolling, otherwise production scroll anchoring
+  // can restore the old position and leave the new panel behind the header.
+  useEffect(() => {
+    if (!isSettingsOpen) return;
+    const frame = window.requestAnimationFrame(() => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isSettingsOpen]);
+
   // Warm the piano-sample cache before the first user gesture so the first
   // Play/preview sounds the sampled piano, not the 8bit fallback. Keyed on the
   // pitch range: only the samples this song can sound are fetched, and widening
@@ -378,12 +389,8 @@ export default function Home() {
   };
 
   const handleToggleSettings = () => {
-    const willOpen = !isSettingsOpen;
-    setIsSettingsOpen(willOpen);
+    setIsSettingsOpen((prev) => !prev);
     setIsConfirmingReset(false);
-    if (willOpen) {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
   };
 
   const handleNoteChipClick = useCallback(


### PR DESCRIPTION
## 変更内容

- 設定パネルを開くイベント内で即時実行していたスクロール補正を削除
- `isSettingsOpen` の変更後、ReactがパネルをDOMへ反映した次の描画フレームでスクロールするよう変更
- パネルを閉じた場合は予約済みフレームをキャンセル

## Root cause

PR #114の本番確認で、設定パネルを挿入するstate更新と `window.scrollTo()` が同じイベント内にありました。production buildではscrollがReactのDOM反映より先に実行され、その後のパネル挿入とブラウザのスクロールアンカーによって元の位置へ戻されていました。

## 確認内容

ローカルのproduction buildを `next start` で起動し、390×500pxで確認しました。

- スクロール中もheader top = 0px
- 設定クリック後: scrollY = 0px
- 設定パネル上端 = 189px（固定ヘッダー下端と一致）
- ブラウザコンソールエラーなし
- TypeScript型チェック
- ESLint
- Vitest: 106 tests passed
- production build

Closes #113