### PR TITLE
設定パネルのスクロール補正をブラウザ互換にする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,7 +125,7 @@ export default function Home() {
   useEffect(() => {
     if (!isSettingsOpen) return;
     const frame = window.requestAnimationFrame(() => {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      window.scrollTo(0, 0);
     });
     return () => window.cancelAnimationFrame(frame);
   }, [isSettingsOpen]);


### PR DESCRIPTION
## 変更内容

設定パネル描画後のスクロールを、オブジェクト形式のsmooth scrollから広く対応している数値形式 `window.scrollTo(0, 0)` へ変更します。

## Root cause

本番URLのブラウザ検証で `window.scrollTo({ top: 0, behavior: 'smooth' })` がスクロール位置を変更しない環境を確認しました。同じ環境で数値形式と `behavior: 'auto'` は正常に動作しました。

設定パネルを確実に表示することを優先し、描画完了後の次フレームという実行タイミングは維持したまま、即時スクロールへ変更しています。

## 確認内容

ローカルproduction build（390×500px）:

- スクロール前: scrollY = 265.5px、header top = 0px
- 設定クリック後: scrollY = 0px
- header bottom = 189px
- settings panel top = 189px
- ブラウザコンソールエラーなし
- TypeScript型チェック
- ESLint
- Vitest: 106 tests passed
- production build

Closes #113