### PR TITLE
fix(discovery): 2回目以降の中央演出を止め、チップを「ずかん」に

### DIFF
--- a/src/app/components/discovery/DiscoveryEffectLayer.test.ts
+++ b/src/app/components/discovery/DiscoveryEffectLayer.test.ts
@@ -8,10 +8,7 @@ describe('DiscoveryEffectLayer', () => {
   it('uses the matching creature for each short non-modal reaction', () => {
     const markup = renderToStaticMarkup(
       createElement(DiscoveryEffectLayer, {
-        events: CREATURES.map((creature, index) => ({
-          key: index,
-          cardId: creature.discoveryId,
-        })),
+        events: CREATURES.map((creature) => creature.discoveryId),
         onEffectEnd: () => undefined,
       }),
     );

--- a/src/app/components/discovery/DiscoveryEffectLayer.tsx
+++ b/src/app/components/discovery/DiscoveryEffectLayer.tsx
@@ -1,24 +1,24 @@
 import Image from 'next/image';
 import { creatureForDiscovery } from '@/creatures/catalog';
-import type { DiscoveryEffectEvent } from '@/discovery/types';
+import type { DiscoveryId } from '@/discovery/types';
 
 interface DiscoveryEffectLayerProps {
-  events: readonly DiscoveryEffectEvent[];
-  onEffectEnd: (key: number) => void;
+  events: readonly DiscoveryId[];
+  onEffectEnd: (cardId: DiscoveryId) => void;
 }
 
 export function DiscoveryEffectLayer({ events, onEffectEnd }: DiscoveryEffectLayerProps) {
   return (
     <div className="discovery-effect-layer" aria-hidden="true">
-      {events.map((event) => {
-        const creature = creatureForDiscovery(event.cardId);
+      {events.map((cardId) => {
+        const creature = creatureForDiscovery(cardId);
         return (
           <div
-            key={event.key}
+            key={cardId}
             className={`discovery-effect discovery-effect--${creature.revealEffect}`}
             onAnimationEnd={(animationEvent) => {
               if (animationEvent.currentTarget === animationEvent.target) {
-                onEffectEnd(event.key);
+                onEffectEnd(cardId);
               }
             }}
           >

--- a/src/app/components/discovery/DiscoveryFeedback.tsx
+++ b/src/app/components/discovery/DiscoveryFeedback.tsx
@@ -1,14 +1,14 @@
 import type { DiscoveryRevealItem } from '@/discovery/revealQueue';
-import type { DiscoveryEffectEvent } from '@/discovery/types';
+import type { DiscoveryId } from '@/discovery/types';
 import type { Translations } from '@/lib/i18n';
 import { DiscoveryEffectLayer } from './DiscoveryEffectLayer';
 import { DiscoveryReveal } from './DiscoveryReveal';
 
 interface DiscoveryFeedbackProps {
-  effects: readonly DiscoveryEffectEvent[];
+  effects: readonly DiscoveryId[];
   revealQueue: readonly DiscoveryRevealItem[];
   t: Translations;
-  onEffectEnd: (key: number) => void;
+  onEffectEnd: (cardId: DiscoveryId) => void;
   onRevealDone: () => void;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,6 @@ import { useDiscoveries } from '@/hooks/useDiscoveries';
 import { useDiscoveryFeedback } from '@/hooks/useDiscoveryFeedback';
 import { useChallengeMode } from '@/hooks/useChallengeMode';
 import { supabase } from '@/lib/supabase';
-import { DISCOVERY_CARDS } from '@/discovery/catalog';
 import { creatureForDiscovery } from '@/creatures/catalog';
 import { SaveModal } from './components/SaveModal';
 import { NotePanel } from './components/NotePanel';
@@ -503,7 +502,7 @@ export default function Home() {
         </button>
         <Link href="/discoveries" className="discovery-chip">
           <span aria-hidden="true">✦</span>
-          {t.discoveryProgress(discoveryProgress.length, DISCOVERY_CARDS.length)}
+          {t.discoveriesLink}
         </Link>
       </div>
 

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -13,7 +13,3 @@ export type DiscoveryMatch = DiscoveryEvidence & {
   triggerStep: number;
 };
 
-export type DiscoveryEffectEvent = {
-  key: number;
-  cardId: DiscoveryId;
-};

--- a/src/hooks/useDiscoveryFeedback.ts
+++ b/src/hooks/useDiscoveryFeedback.ts
@@ -10,7 +10,7 @@ import {
   type DiscoverySourceSnapshot,
 } from '@/discovery/eligibility';
 import { revealItemsFor, type DiscoveryRevealItem } from '@/discovery/revealQueue';
-import type { DiscoveryEffectEvent, DiscoveryId, DiscoveryMatch } from '@/discovery/types';
+import type { DiscoveryId, DiscoveryMatch } from '@/discovery/types';
 
 type Params = {
   song: Song;
@@ -39,9 +39,11 @@ export function useDiscoveryFeedback({
   loadedSongOwnerId,
   claimDiscoveries,
 }: Params) {
-  const [effects, setEffects] = useState<DiscoveryEffectEvent[]>([]);
+  // Two states rather than one because they end differently: an effect clears
+  // itself when its animation finishes, a reveal waits for the child to dismiss
+  // it. A creature can only ever be newly met once, so its id identifies both.
+  const [effects, setEffects] = useState<DiscoveryId[]>([]);
   const [revealQueue, setRevealQueue] = useState<DiscoveryRevealItem[]>([]);
-  const effectKeyRef = useRef(0);
   const sourceRef = useRef<DiscoverySourceSnapshot | null>(null);
   const matchesRef = useRef<Map<number, DiscoveryMatch[]>>(new Map());
 
@@ -71,15 +73,10 @@ export function useDiscoveryFeedback({
       const newlyEarned = claimDiscoveries(earnable);
       if (newlyEarned.length === 0) return false;
 
-      // Only a first meeting animates. The effect layer drops a creature in the
-      // middle of the screen, and a match re-fires on every loop of the song —
-      // so for a creature already met it landed on top of the grid again and
-      // again while the child was trying to work.
-      const nextEffects = newlyEarned.map((cardId) => ({
-        key: effectKeyRef.current++,
-        cardId,
-      }));
-      setEffects((current) => [...current, ...nextEffects].slice(-12));
+      // Only a first meeting animates. The effect drops a creature in the middle
+      // of the screen and a match re-fires on every loop, so for a creature
+      // already met it kept landing on the grid while the child was working.
+      setEffects((current) => [...current, ...newlyEarned]);
       setRevealQueue((current) => [...current, ...revealItemsFor(newlyEarned, matches)]);
       return true;
     },
@@ -87,8 +84,8 @@ export function useDiscoveryFeedback({
   );
 
   const clearEffects = useCallback(() => setEffects([]), []);
-  const dismissEffect = useCallback((key: number) => {
-    setEffects((current) => current.filter((event) => event.key !== key));
+  const dismissEffect = useCallback((cardId: DiscoveryId) => {
+    setEffects((current) => current.filter((id) => id !== cardId));
   }, []);
   const finishReveal = useCallback(() => {
     setRevealQueue((current) => current.slice(1));

--- a/src/hooks/useDiscoveryFeedback.ts
+++ b/src/hooks/useDiscoveryFeedback.ts
@@ -63,24 +63,25 @@ export function useDiscoveryFeedback({
       const matches = matchesRef.current.get(step);
       if (!matches || matches.length === 0) return false;
 
-      const effectCardIds = [...new Set(matches.map((match) => match.cardId))];
-      const nextEffects = effectCardIds.map((cardId) => ({
-        key: effectKeyRef.current++,
-        cardId,
-      }));
-      setEffects((current) => [...current, ...nextEffects].slice(-12));
-
       const source =
         currentUserId && loadedSongOwnerId === currentUserId ? null : sourceRef.current;
       const earnable = matches
         .filter((match) => hasUserContribution(match, songRef.current, source))
         .map((match) => match.cardId);
       const newlyEarned = claimDiscoveries(earnable);
-      if (newlyEarned.length > 0) {
-        setRevealQueue((current) => [...current, ...revealItemsFor(newlyEarned, matches)]);
-        return true;
-      }
-      return false;
+      if (newlyEarned.length === 0) return false;
+
+      // Only a first meeting animates. The effect layer drops a creature in the
+      // middle of the screen, and a match re-fires on every loop of the song —
+      // so for a creature already met it landed on top of the grid again and
+      // again while the child was trying to work.
+      const nextEffects = newlyEarned.map((cardId) => ({
+        key: effectKeyRef.current++,
+        cardId,
+      }));
+      setEffects((current) => [...current, ...nextEffects].slice(-12));
+      setRevealQueue((current) => [...current, ...revealItemsFor(newlyEarned, matches)]);
+      return true;
     },
     [claimDiscoveries, currentUserId, loadedSongOwnerId, songRef],
   );


### PR DESCRIPTION
## 修正2点

### ① 発見済みの生き物が毎回、画面中央に出続ける

出現演出は**画面中央にキャラクターを表示**しますが、これが**発見済みかどうかに関係なく毎回発火**していました。しかも判定は**曲がループするたびに再発火**するため、**作業中のグリッドの上に何度も生き物が降ってくる**状態でした。

初回の出会いのときだけ演出するよう変更。**一度会った生き物との再会は「お知らせ」ではない**ためです。

> ※これは #108 の当初設計（「獲得済みでも通常の視覚反応は毎回表示する」）を狭めます。実装された「反応」が控えめなものではなく**画面中央の等身大ポートレート**だったためです。控えめな常時フィードバックは将来入れ直せますが、現状のものは止めるべきでした。

### ② ヘッダーのチップ「5 / 8 と であった」

混み合ったヘッダーで最も幅を取る要素が数字に費やされていました。リンク先は図鑑なので **「ずかん」** に。

## 検証（ブラウザ実測）

| ケース | 結果 |
|---|---|
| **発見済み**の3度を3ループ再生 | 中央エフェクト **0件**・モーダルなし ✅ |
| **未発見**に戻して再生 | エフェクト表示・**「であった！ ミッツ」** ✅（初回は従来どおり） |
| チップ表示 | **「✦ ずかん」** ✅ |

コンソールエラーなし、`tsc`/`lint` クリーン、135テスト通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)